### PR TITLE
Refactoring to handle all navigation in the navigation.kt file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.iml
 .gradle
 /local.properties
+/.idea
 /.idea/caches
 /.idea/libraries
 /.idea/modules.xml

--- a/app/src/main/java/app/myzel394/alibi/ui/Navigation.kt
+++ b/app/src/main/java/app/myzel394/alibi/ui/Navigation.kt
@@ -1,18 +1,5 @@
 package app.myzel394.alibi.ui
 
-import android.content.Context
-import android.hardware.biometrics.BiometricManager.Authenticators.BIOMETRIC_STRONG
-import android.hardware.biometrics.BiometricManager.Authenticators.DEVICE_CREDENTIAL
-import android.hardware.biometrics.BiometricPrompt
-import android.hardware.biometrics.BiometricPrompt.CryptoObject
-import android.hardware.camera2.CameraCharacteristics
-import android.hardware.camera2.CameraManager
-import android.os.Build
-import android.os.CancellationSignal
-import android.widget.Button
-import androidx.annotation.RequiresApi
-import androidx.appcompat.app.AppCompatDelegate
-import androidx.camera.core.CameraX
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -24,28 +11,22 @@ import androidx.compose.foundation.background
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import app.myzel394.alibi.R
 import app.myzel394.alibi.dataStore
-import app.myzel394.alibi.db.AppSettings
 import app.myzel394.alibi.ui.enums.Screen
 import app.myzel394.alibi.ui.models.AudioRecorderModel
 import app.myzel394.alibi.ui.models.VideoRecorderModel
 import app.myzel394.alibi.ui.screens.AboutScreen
-import app.myzel394.alibi.ui.screens.RecorderScreen
 import app.myzel394.alibi.ui.screens.CustomRecordingNotificationsScreen
+import app.myzel394.alibi.ui.screens.RecorderScreen
 import app.myzel394.alibi.ui.screens.SettingsScreen
 import app.myzel394.alibi.ui.screens.WelcomeScreen
-import app.myzel394.alibi.ui.utils.CameraInfo
-import app.myzel394.alibi.helpers.AppLockHelper
 
 const val SCALE_IN = 1.25f
 
@@ -79,7 +60,7 @@ fun Navigation(
         startDestination = if (settings.hasSeenOnboarding) Screen.AudioRecorder.route else Screen.Welcome.route,
     ) {
         composable(Screen.Welcome.route) {
-            WelcomeScreen(navController = navController)
+            WelcomeScreen(onNavigateToAudioRecorderScreen = { navController.navigate(Screen.AudioRecorder.route) })
         }
         composable(
             Screen.AudioRecorder.route,
@@ -94,7 +75,9 @@ fun Navigation(
             }
         ) {
             RecorderScreen(
-                navController = navController,
+                onNavigateToSettingsScreen = {
+                    navController.navigate(Screen.Settings.route)
+                },
                 audioRecorder = audioRecorder,
                 videoRecorder = videoRecorder,
                 settings = settings,
@@ -110,7 +93,11 @@ fun Navigation(
             }
         ) {
             SettingsScreen(
-                navController = navController,
+                onBackNavigate = navController::popBackStack,
+                onNavigateToCustomRecordingNotifications = {
+                    navController.navigate(Screen.CustomRecordingNotifications.route)
+                },
+                onNavigateToAboutScreen = { navController.navigate(Screen.About.route) },
                 audioRecorder = audioRecorder,
                 videoRecorder = videoRecorder,
             )
@@ -129,7 +116,7 @@ fun Navigation(
             }
         ) {
             CustomRecordingNotificationsScreen(
-                navController = navController,
+                onBackNavigate = navController::popBackStack
             )
         }
         composable(
@@ -142,7 +129,7 @@ fun Navigation(
             }
         ) {
             AboutScreen(
-                navController = navController,
+                onBackNavigate = navController::popBackStack,
             )
         }
     }

--- a/app/src/main/java/app/myzel394/alibi/ui/components/SettingsScreen/Tiles/AboutTile.kt
+++ b/app/src/main/java/app/myzel394/alibi/ui/components/SettingsScreen/Tiles/AboutTile.kt
@@ -31,7 +31,7 @@ import app.myzel394.alibi.ui.enums.Screen
 
 @Composable
 fun AboutTile(
-    navController: NavController,
+    onNavigateToAboutScreen: () -> Unit,
 ) {
     val label = stringResource(R.string.ui_about_title)
 
@@ -44,7 +44,7 @@ fun AboutTile(
                 contentDescription = label
             }
             .clickable {
-                navController.navigate(Screen.About.route)
+                onNavigateToAboutScreen()
             }
             .background(MaterialTheme.colorScheme.surfaceVariant)
             .padding(16.dp),

--- a/app/src/main/java/app/myzel394/alibi/ui/components/SettingsScreen/Tiles/CustomNotificationTile.kt
+++ b/app/src/main/java/app/myzel394/alibi/ui/components/SettingsScreen/Tiles/CustomNotificationTile.kt
@@ -21,7 +21,7 @@ import app.myzel394.alibi.ui.enums.Screen
 
 @Composable
 fun CustomNotificationTile(
-    navController: NavController,
+    onNavigateToCustomRecordingNotifications: () -> Unit,
     settings: AppSettings,
 ) {
     val dataStore = LocalContext.current.dataStore
@@ -35,7 +35,8 @@ fun CustomNotificationTile(
     SettingsTile(
         firstModifier = Modifier
             .clickable {
-                navController.navigate(Screen.CustomRecordingNotifications.route)
+
+                onNavigateToCustomRecordingNotifications()
             }
             .semantics { contentDescription = label },
         title = stringResource(R.string.ui_settings_option_customNotification_title),

--- a/app/src/main/java/app/myzel394/alibi/ui/screens/AboutScreen.kt
+++ b/app/src/main/java/app/myzel394/alibi/ui/screens/AboutScreen.kt
@@ -53,7 +53,7 @@ import app.myzel394.alibi.ui.components.AboutScreen.atoms.GPGKeyOverview
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AboutScreen(
-    navController: NavController,
+    onBackNavigate: () -> Unit
 ) {
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(
         rememberTopAppBarState()
@@ -67,7 +67,7 @@ fun AboutScreen(
                     Text(stringResource(R.string.ui_about_title))
                 },
                 navigationIcon = {
-                    IconButton(onClick = navController::popBackStack) {
+                    IconButton(onClick = onBackNavigate) {
                         Icon(
                             Icons.Default.ArrowBack,
                             contentDescription = "Back"

--- a/app/src/main/java/app/myzel394/alibi/ui/screens/CustomRecordingNotificationsScreen.kt
+++ b/app/src/main/java/app/myzel394/alibi/ui/screens/CustomRecordingNotificationsScreen.kt
@@ -50,7 +50,7 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CustomRecordingNotificationsScreen(
-    navController: NavController,
+    onBackNavigate: () -> Unit
 ) {
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(
         rememberTopAppBarState()
@@ -79,7 +79,7 @@ fun CustomRecordingNotificationsScreen(
                     Text(stringResource(R.string.ui_settings_option_customNotification_title))
                 },
                 navigationIcon = {
-                    IconButton(onClick = navController::popBackStack) {
+                    IconButton(onClick = onBackNavigate) {
                         Icon(
                             Icons.Default.ArrowBack,
                             contentDescription = "Back"
@@ -110,7 +110,7 @@ fun CustomRecordingNotificationsScreen(
                             })
                         }
                     }
-                    navController.popBackStack()
+                    onBackNavigate()
                 }
             )
         } else {

--- a/app/src/main/java/app/myzel394/alibi/ui/screens/RecorderScreen.kt
+++ b/app/src/main/java/app/myzel394/alibi/ui/screens/RecorderScreen.kt
@@ -36,7 +36,7 @@ import app.myzel394.alibi.ui.models.VideoRecorderModel
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RecorderScreen(
-    navController: NavController,
+    onNavigateToSettingsScreen: () -> Unit,
     audioRecorder: AudioRecorderModel,
     videoRecorder: VideoRecorderModel,
     settings: AppSettings,
@@ -82,7 +82,7 @@ fun RecorderScreen(
                     actions = {
                         IconButton(
                             onClick = {
-                                navController.navigate(Screen.Settings.route)
+                                onNavigateToSettingsScreen()
                             },
                         ) {
                             Icon(

--- a/app/src/main/java/app/myzel394/alibi/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/app/myzel394/alibi/ui/screens/SettingsScreen.kt
@@ -66,7 +66,9 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
-    navController: NavController,
+    onBackNavigate: () -> Unit,
+    onNavigateToCustomRecordingNotifications: () -> Unit,
+    onNavigateToAboutScreen: () -> Unit,
     audioRecorder: AudioRecorderModel,
     videoRecorder: VideoRecorderModel,
 ) {
@@ -97,7 +99,7 @@ fun SettingsScreen(
                     Text(stringResource(R.string.ui_settings_title))
                 },
                 navigationIcon = {
-                    IconButton(onClick = navController::popBackStack) {
+                    IconButton(onClick = onBackNavigate) {
                         Icon(
                             Icons.Default.ArrowBack,
                             contentDescription = "Back"
@@ -141,7 +143,7 @@ fun SettingsScreen(
             IntervalDurationTile(settings = settings)
             InAppLanguagePicker()
             DeleteRecordingsImmediatelyTile(settings = settings)
-            CustomNotificationTile(navController = navController, settings = settings)
+            CustomNotificationTile(onNavigateToCustomRecordingNotifications, settings = settings)
             EnableAppLockTile(settings = settings)
             SaveFolderTile(
                 settings = settings,
@@ -191,7 +193,7 @@ fun SettingsScreen(
                     ImportExport(snackbarHostState = snackbarHostState)
                 }
             }
-            AboutTile(navController = navController)
+            AboutTile(onNavigateToAboutScreen)
         }
     }
 }

--- a/app/src/main/java/app/myzel394/alibi/ui/screens/WelcomeScreen.kt
+++ b/app/src/main/java/app/myzel394/alibi/ui/screens/WelcomeScreen.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun WelcomeScreen(
-    navController: NavController,
+    onNavigateToAudioRecorderScreen: () -> Unit
 ) {
     val context = LocalContext.current
     val dataStore = context.dataStore
@@ -59,7 +59,7 @@ fun WelcomeScreen(
                             dataStore.updateData {
                                 settings.setHasSeenOnboarding(true)
                             }
-                            navController.navigate(Screen.AudioRecorder.route)
+                            onNavigateToAudioRecorderScreen()
                         }
                     }
                 }


### PR DESCRIPTION
First part of refactoring, this one just stood out. It's best practice to handle all navigation in one unit and not pass down nav controller for screens to handle their own navigation but to request navigation back to the navigation unit.