### PR TITLE
Fix audio processing when saving

### DIFF
--- a/app/src/main/java/app/myzel394/alibi/ui/components/RecorderScreen/organisms/RecorderEventsHandler.kt
+++ b/app/src/main/java/app/myzel394/alibi/ui/components/RecorderScreen/organisms/RecorderEventsHandler.kt
@@ -176,14 +176,18 @@ fun RecorderEventsHandler(
                         else -> throw Exception("Unknown recorder type")
                     }
 
-                    batchesFolder.concatenate(
-                        recording.recordingStart,
-                        recording.fileExtension,
-                        durationPerBatchInMilliseconds = settings.intervalDuration,
-                        onProgress = { percentage ->
-                            processingProgress = percentage
-                        }
-                    )
+                    val outputFile = if (batchesFolder.getBatchesForFFmpeg().size == 1) {
+                        batchesFolder.getBatchesForFFmpeg().first()
+                    } else {
+                        batchesFolder.concatenate(
+                            recording.recordingStart,
+                            recording.fileExtension,
+                            durationPerBatchInMilliseconds = settings.intervalDuration,
+                            onProgress = { percentage ->
+                                processingProgress = percentage
+                            }
+                        )
+                    }
 
                     // Save file
                     val name = batchesFolder.getName(
@@ -196,19 +200,13 @@ fun RecorderEventsHandler(
                             when (batchesFolder) {
                                 is AudioBatchesFolder -> {
                                     saveAudioFile(
-                                        batchesFolder.asInternalGetOutputFile(
-                                            recording.recordingStart,
-                                            recording.fileExtension,
-                                        ), name
+                                        outputFile, name
                                     )
                                 }
 
                                 is VideoBatchesFolder -> {
                                     saveVideoFile(
-                                        batchesFolder.asInternalGetOutputFile(
-                                            recording.recordingStart,
-                                            recording.fileExtension,
-                                        ), name
+                                        outputFile, name
                                     )
                                 }
                             }


### PR DESCRIPTION
Related to #112

Update the `saveRecording` function in `RecorderEventsHandler.kt` to handle the case where there is only one batch and skip processing.

* Add a check to see if there is only one batch and skip concatenation if true.
* Modify the `saveRecording` function to use the single batch file path if there is only one batch.
* Update the `saveAudioFile` and `saveVideoFile` calls to use the single batch file path if there is only one batch.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Myzel394/Alibi/issues/112?shareId=5791d81d-239f-40c7-ba9e-37316345281e).