### PR TITLE
fix: Reinstate the filename format setting

### DIFF
--- a/app/src/main/java/app/myzel394/alibi/helpers/AudioBatchesFolder.kt
+++ b/app/src/main/java/app/myzel394/alibi/helpers/AudioBatchesFolder.kt
@@ -16,7 +16,6 @@ import app.myzel394.alibi.ui.RECORDER_MEDIA_SELECTED_VALUE
 import com.arthenica.ffmpegkit.FFmpegKitConfig
 import java.io.File
 import java.io.FileDescriptor
-import java.time.LocalDateTime
 
 class AudioBatchesFolder(
     override val context: Context,
@@ -38,7 +37,6 @@ class AudioBatchesFolder(
     private var mediaFileFileDescriptor: ParcelFileDescriptor? = null
 
     override fun getOutputFileForFFmpeg(
-        date: LocalDateTime,
         extension: String,
         fileName: String,
     ): String {

--- a/app/src/main/java/app/myzel394/alibi/helpers/BatchesFolder.kt
+++ b/app/src/main/java/app/myzel394/alibi/helpers/BatchesFolder.kt
@@ -235,7 +235,6 @@ abstract class BatchesFolder(
     }
 
     abstract fun getOutputFileForFFmpeg(
-        date: LocalDateTime,
         extension: String,
         fileName: String,
     ): String
@@ -244,19 +243,16 @@ abstract class BatchesFolder(
 
     suspend fun concatenate(
         recording: RecordingInformation,
-        filenameFormat: AppSettings.FilenameFormat,
         disableCache: Boolean? = null,
         onNextParameterTry: (String) -> Unit = {},
         onProgress: (Float?) -> Unit = {},
         fileName: String,
     ): String {
         val disableCache = disableCache ?: (type != BatchType.INTERNAL)
-        val date = recording.getStartDateForFilename(filenameFormat)
 
         if (!disableCache && checkIfOutputAlreadyExists(fileName)
         ) {
             return getOutputFileForFFmpeg(
-                date = recording.recordingStart,
                 extension = recording.fileExtension,
                 fileName = fileName,
             )
@@ -272,7 +268,6 @@ abstract class BatchesFolder(
                 val filePaths = getBatchesForFFmpeg()
 
                 val outputFile = getOutputFileForFFmpeg(
-                    date = date,
                     extension = recording.fileExtension,
                     fileName = fileName,
                 )

--- a/app/src/main/java/app/myzel394/alibi/helpers/VideoBatchesFolder.kt
+++ b/app/src/main/java/app/myzel394/alibi/helpers/VideoBatchesFolder.kt
@@ -16,7 +16,6 @@ import app.myzel394.alibi.ui.RECORDER_MEDIA_SELECTED_VALUE
 import app.myzel394.alibi.ui.VIDEO_RECORDING_BATCHES_SUBFOLDER_NAME
 import com.arthenica.ffmpegkit.FFmpegKitConfig
 import java.io.File
-import java.time.LocalDateTime
 
 class VideoBatchesFolder(
     override val context: Context,
@@ -40,7 +39,6 @@ class VideoBatchesFolder(
     private var customParcelFileDescriptor: ParcelFileDescriptor? = null
 
     override fun getOutputFileForFFmpeg(
-        date: LocalDateTime,
         extension: String,
         fileName: String,
     ): String {

--- a/app/src/main/java/app/myzel394/alibi/ui/components/RecorderScreen/organisms/RecorderEventsHandler.kt
+++ b/app/src/main/java/app/myzel394/alibi/ui/components/RecorderScreen/organisms/RecorderEventsHandler.kt
@@ -178,13 +178,12 @@ fun RecorderEventsHandler(
                     }
 
                     val fileName = batchesFolder.getName(
-                        recording.recordingStart,
+                        recording.getStartDateForFilename(filenameFormat = settings.filenameFormat),
                         recording.fileExtension,
                     )
 
                     batchesFolder.concatenate(
                         recording,
-                        filenameFormat = settings.filenameFormat,
                         fileName = fileName,
                         onProgress = { percentage ->
                             processingProgress = percentage


### PR DESCRIPTION
Should fix #127

By the way, what does `checkIfOutputAlreadyExists` do? It doesn't seem to prevent old files with the same name from being overwritten despite this check.