### PR TITLE
fix: make video export work on Android 11+

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -123,7 +123,12 @@ dependencies {
 
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.1'
 
-    implementation 'com.arthenica:ffmpeg-kit-full-gpl:5.1'
+    // The `full-gpl` variant of this fork ships a broken libavdevice.so that
+    // dlopens unresolved `PLATFORM_hid_*` symbols (libhidapi isn't bundled),
+    // which makes FFmpegKit fail to initialize. We don't need libass/libx264 any
+    // more now that overlays are rendered live via OpenGL and concat uses `-c copy`,
+    // so stick to the plain `main` variant.
+    implementation 'io.github.jamaismagic.ffmpeg:ffmpeg-kit-main-16kb:6.1.4'
 
     implementation "androidx.datastore:datastore-preferences:1.1.1"
 

--- a/app/src/main/java/app/myzel394/alibi/helpers/BatchesFolder.kt
+++ b/app/src/main/java/app/myzel394/alibi/helpers/BatchesFolder.kt
@@ -26,6 +26,7 @@ import app.myzel394.alibi.ui.SUPPORTS_SCOPED_STORAGE
 import app.myzel394.alibi.ui.utils.PermissionHelper
 import com.arthenica.ffmpegkit.FFmpegKitConfig
 import kotlinx.coroutines.CompletableDeferred
+import java.io.Closeable
 import java.io.File
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -42,6 +43,83 @@ abstract class BatchesFolder(
     abstract val ffmpegParameters: Array<String>
     abstract val scopedMediaContentUri: Uri
     abstract val legacyMediaFolder: File
+
+    data class BatchFile(
+        val counter: Long,
+        val ffmpegPath: String,
+    )
+
+    protected data class UriBatchFile(
+        val counter: Long,
+        val uri: Uri,
+        val rawName: String,
+    )
+
+    protected class FFmpegInputPaths(
+        val paths: List<String>,
+        private val closeables: List<Closeable> = emptyList(),
+    ) : Closeable {
+        override fun close() {
+            closeables.forEach {
+                runCatching {
+                    it.close()
+                }
+            }
+        }
+    }
+
+    protected class FFmpegOutputTarget(
+        val ffmpegPath: String,
+        private val closeable: Closeable? = null,
+        private val onCommit: () -> String = { ffmpegPath },
+        private val onAbort: () -> Unit = {},
+    ) : Closeable {
+        private var closed = false
+        private var finished = false
+
+        override fun close() {
+            if (closed) {
+                return
+            }
+
+            runCatching {
+                closeable?.close()
+            }
+            closed = true
+        }
+
+        fun commit(): String {
+            close()
+            return try {
+                onCommit().also {
+                    finished = true
+                }
+            } catch (error: Exception) {
+                onAbort()
+                finished = true
+                throw error
+            }
+        }
+
+        fun abort() {
+            if (finished) {
+                return
+            }
+
+            close()
+            onAbort()
+            finished = true
+        }
+    }
+
+    protected class FFmpegFileDescriptorPath(
+        val path: String,
+        private val parcelFileDescriptor: ParcelFileDescriptor,
+    ) : Closeable {
+        override fun close() {
+            parcelFileDescriptor.close()
+        }
+    }
 
     val mediaPrefix
         get() = MEDIA_RECORDINGS_PREFIX + subfolderName.substring(1) + "-"
@@ -117,46 +195,294 @@ abstract class BatchesFolder(
         }
     }
 
-    fun getBatchesForFFmpeg(): List<String> {
+    private fun Cursor.mediaSize(): Long? {
+        val sizeColumn = getColumnIndex(MediaStore.MediaColumns.SIZE)
+        if (sizeColumn == -1 || isNull(sizeColumn)) {
+            return null
+        }
+
+        return getLong(sizeColumn)
+    }
+
+    private fun isUsableMediaSize(size: Long?) = size == null || size > 0L
+
+    fun getBatchesForFFmpeg(): List<String> =
+        getBatchesForFFmpegBatches().map {
+            it.ffmpegPath
+        }
+
+    protected fun openUriPathForFFmpeg(
+        uri: Uri,
+        mode: String,
+    ): FFmpegFileDescriptorPath {
+        val parcelFileDescriptor = context.contentResolver.openFileDescriptor(uri, mode)
+            ?: throw MediaConverter.FFmpegException("Unable to open media file")
+
+        return FFmpegFileDescriptorPath(
+            path = "fd:${parcelFileDescriptor.fd}",
+            parcelFileDescriptor = parcelFileDescriptor,
+        )
+    }
+
+    protected fun getUriBatchesForFFmpeg(): List<UriBatchFile> {
+        return when (type) {
+            BatchType.CUSTOM -> getCustomDefinedFolder()
+                .listFiles()
+                .filter {
+                    it.name?.substringBeforeLast(".")?.toIntOrNull() != null && it.length() > 0L
+                }
+                .sortedBy {
+                    it.name!!.substringBeforeLast(".").toInt()
+                }
+                .map {
+                    UriBatchFile(
+                        counter = it.name!!.substringBeforeLast(".").toLong(),
+                        uri = it.uri,
+                        rawName = it.name!!,
+                    )
+                }
+
+            BatchType.MEDIA -> {
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+                    throw IllegalStateException("Legacy media batches do not use content URIs")
+                }
+
+                val fileUris = mutableListOf<UriBatchFile>()
+
+                queryMediaContent { rawName, counter, uri, cursor ->
+                    if (isUsableMediaSize(cursor.mediaSize())) {
+                        fileUris.add(
+                            UriBatchFile(
+                                counter = counter.toLong(),
+                                uri = uri,
+                                rawName = rawName,
+                            )
+                        )
+                    }
+                }
+
+                fileUris
+                    .sortedBy {
+                        it.rawName
+                            .substring(mediaPrefix.length)
+                            .substringBeforeLast(".")
+                            .toInt()
+                    }
+            }
+
+            BatchType.INTERNAL -> throw IllegalStateException("Internal batches do not use content URIs")
+        }
+    }
+
+    protected open fun prepareInputPathsForFFmpeg(extension: String): FFmpegInputPaths =
+        FFmpegInputPaths(getBatchesForFFmpeg())
+
+    protected open fun prepareOutputTargetForFFmpeg(
+        date: LocalDateTime,
+        extension: String,
+        fileName: String,
+    ): FFmpegOutputTarget {
+        val outputFile = getOutputFileForFFmpeg(
+            date = date,
+            extension = extension,
+            fileName = fileName,
+        )
+
+        return FFmpegOutputTarget(
+            ffmpegPath = outputFile,
+            onCommit = { outputFile },
+        )
+    }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    protected fun createMediaFile(
+        name: String,
+        mimeType: String,
+        relativePath: String,
+        isPending: Boolean = false,
+    ): Uri {
+        return context.contentResolver.insert(
+            scopedMediaContentUri,
+            ContentValues().apply {
+                put(
+                    MediaStore.MediaColumns.DISPLAY_NAME,
+                    name
+                )
+                put(
+                    MediaStore.MediaColumns.MIME_TYPE,
+                    mimeType
+                )
+
+                put(
+                    MediaStore.MediaColumns.RELATIVE_PATH,
+                    relativePath,
+                )
+                put(
+                    MediaStore.MediaColumns.IS_PENDING,
+                    if (isPending) 1 else 0,
+                )
+            }
+        ) ?: throw MediaConverter.FFmpegException("Unable to create export destination")
+    }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    protected fun deleteMediaFileByName(fileName: String) {
+        context.contentResolver.delete(
+            scopedMediaContentUri,
+            "${MediaStore.MediaColumns.DISPLAY_NAME} = ?",
+            arrayOf(fileName),
+        )
+    }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    protected fun publishPendingMediaFile(
+        uri: Uri,
+        fileName: String,
+    ) {
+        deleteMediaFileByName(fileName)
+
+        val updated = context.contentResolver.update(
+            uri,
+            ContentValues().apply {
+                put(
+                    MediaStore.MediaColumns.DISPLAY_NAME,
+                    fileName,
+                )
+                put(
+                    MediaStore.MediaColumns.IS_PENDING,
+                    0,
+                )
+            },
+            null,
+            null,
+        )
+
+        if (updated != 1) {
+            throw MediaConverter.FFmpegException("Unable to publish export destination")
+        }
+    }
+
+    open fun getBatchCountersForFFmpeg(): List<Long> {
+        return when (type) {
+            BatchType.INTERNAL ->
+                getInternalFolder()
+                    .listFiles()
+                    ?.filter {
+                        it.nameWithoutExtension.toIntOrNull() != null && it.length() > 0L
+                    }
+                    ?.sortedBy {
+                        it.nameWithoutExtension.toInt()
+                    }
+                    ?.map {
+                        it.nameWithoutExtension.toLong()
+                    } ?: emptyList()
+
+            BatchType.CUSTOM -> getCustomDefinedFolder()
+                .listFiles()
+                .filter {
+                    it.name?.substringBeforeLast(".")?.toIntOrNull() != null && it.length() > 0L
+                }
+                .sortedBy {
+                    it.name!!.substringBeforeLast(".").toInt()
+                }
+                .map {
+                    it.name!!.substringBeforeLast(".").toLong()
+                }
+
+            BatchType.MEDIA -> {
+                val counters = mutableListOf<Pair<String, Long>>()
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    queryMediaContent { rawName, counter, _, cursor ->
+                        if (isUsableMediaSize(cursor.mediaSize())) {
+                            counters.add(Pair(rawName, counter.toLong()))
+                        }
+                    }
+                } else {
+                    legacyMediaFolder.listFiles()?.forEach {
+                        if (it.name.startsWith(mediaPrefix) && it.length() > 0L) {
+                            counters.add(
+                                Pair(
+                                    it.name,
+                                    it.name
+                                        .substring(mediaPrefix.length)
+                                        .substringBeforeLast(".")
+                                        .toLongOrNull() ?: return@forEach
+                                )
+                            )
+                        }
+                    }
+                }
+
+                counters
+                    .sortedBy { (name, _) ->
+                        name
+                            .substring(mediaPrefix.length)
+                            .substringBeforeLast(".")
+                            .toInt()
+                    }
+                    .map { (_, counter) -> counter }
+            }
+        }
+    }
+
+    fun getBatchesForFFmpegBatches(): List<BatchFile> {
         return when (type) {
             BatchType.INTERNAL ->
                 ((getInternalFolder()
                     .listFiles()
                     ?.filter {
-                        it.nameWithoutExtension.toIntOrNull() != null
+                        it.nameWithoutExtension.toIntOrNull() != null && it.length() > 0L
                     }
                     ?.toList()
                     ?: emptyList()) as List<File>)
                     .sortedBy {
                         it.nameWithoutExtension.toInt()
                     }
-                    .map { it.absolutePath }
+                    .map {
+                        BatchFile(
+                            counter = it.nameWithoutExtension.toLong(),
+                            ffmpegPath = it.absolutePath,
+                        )
+                    }
 
             BatchType.CUSTOM -> getCustomDefinedFolder()
                 .listFiles()
                 .filter {
-                    it.name?.substringBeforeLast(".")?.toIntOrNull() != null
+                    it.name?.substringBeforeLast(".")?.toIntOrNull() != null && it.length() > 0L
                 }
                 .sortedBy {
                     it.name!!.substringBeforeLast(".").toInt()
                 }
                 .map {
-                    FFmpegKitConfig.getSafParameterForRead(
-                        context,
-                        it.uri,
-                    )!!
+                    BatchFile(
+                        counter = it.name!!.substringBeforeLast(".").toLong(),
+                        ffmpegPath = FFmpegKitConfig.getSafParameterForRead(
+                            context,
+                            it.uri,
+                        )!!,
+                    )
                 }
 
             BatchType.MEDIA -> {
-                val fileUris = mutableListOf<Pair<String, Uri>>()
+                val fileUris = mutableListOf<Triple<String, Long, Uri>>()
 
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    queryMediaContent { rawName, _, uri, _ ->
-                        fileUris.add(Pair(rawName, uri))
+                    queryMediaContent { rawName, counter, uri, cursor ->
+                        if (isUsableMediaSize(cursor.mediaSize())) {
+                            fileUris.add(Triple(rawName, counter.toLong(), uri))
+                        }
                     }
                 } else {
                     legacyMediaFolder.listFiles()?.forEach {
-                        fileUris.add(Pair(it.name, it.toUri()))
+                        if (it.name.startsWith(mediaPrefix) && it.length() > 0L) {
+                            val counter = it.name
+                                .substring(mediaPrefix.length)
+                                .substringBeforeLast(".")
+                                .toLongOrNull() ?: return@forEach
+
+                            fileUris.add(Triple(it.name, counter, it.toUri()))
+                        }
                     }
                 }
 
@@ -169,17 +495,66 @@ abstract class BatchesFolder(
                             .substringBeforeLast(".")
                             .toInt()
                     }
-                    .map { pair ->
-                        val uri = pair.second
-
-                        FFmpegKitConfig.getSafParameterForRead(
-                            context,
-                            uri,
-                        )!!
+                    .map { (_, counter, uri) ->
+                        BatchFile(
+                            counter = counter,
+                            ffmpegPath = FFmpegKitConfig.getSafParameterForRead(
+                                context,
+                                uri,
+                            )!!,
+                        )
                     }
             }
         }
     }
+
+    fun getBatchesAmount(): Int {
+        return when (type) {
+            BatchType.INTERNAL ->
+                getInternalFolder()
+                    .listFiles()
+                    ?.count {
+                        it.nameWithoutExtension.toIntOrNull() != null && it.length() > 0L
+                    } ?: 0
+
+            BatchType.CUSTOM -> getCustomDefinedFolder()
+                .listFiles()
+                .count {
+                    it.name?.substringBeforeLast(".")?.toIntOrNull() != null && it.length() > 0L
+                }
+
+            BatchType.MEDIA -> {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    var count = 0
+                    queryMediaContent { _, _, _, cursor ->
+                        if (isUsableMediaSize(cursor.mediaSize())) {
+                            count += 1
+                        }
+                        true
+                    }
+                    return count
+                }
+
+                legacyMediaFolder
+                    .listFiles()
+                    ?.count {
+                        if (!it.name.startsWith(mediaPrefix)) {
+                            return@count false
+                        }
+
+                        it.name
+                            .substring(mediaPrefix.length)
+                            .substringBeforeLast(".")
+                            .toIntOrNull() != null && it.length() > 0L
+                    } ?: 0
+            }
+        }
+    }
+
+    open fun getFFmpegParameters(
+        recording: RecordingInformation,
+        batchCounters: List<Long>,
+    ): Array<String> = ffmpegParameters
 
     fun getName(date: LocalDateTime, extension: String): String {
         val name = date
@@ -262,33 +637,48 @@ abstract class BatchesFolder(
             )
         }
 
-        for (parameter in ffmpegParameters) {
+        for (parameter in getFFmpegParameters(recording, getBatchCountersForFFmpeg())) {
             Log.i("Concatenation", "Trying parameter $parameter")
             onNextParameterTry(parameter)
             onProgress(null)
 
+            var inputPaths: FFmpegInputPaths? = null
+            var outputTarget: FFmpegOutputTarget? = null
+            var completed = false
+
             try {
                 val fullTime = recording.getFullDuration().toFloat();
-                val filePaths = getBatchesForFFmpeg()
+                inputPaths = prepareInputPathsForFFmpeg(recording.fileExtension)
+                if (inputPaths.paths.isEmpty()) {
+                    throw MediaConverter.FFmpegException("No valid media batches available")
+                }
 
-                val outputFile = getOutputFileForFFmpeg(
+                outputTarget = prepareOutputTargetForFFmpeg(
                     date = date,
                     extension = recording.fileExtension,
                     fileName = fileName,
                 )
 
                 concatenationFunction(
-                    filePaths,
-                    outputFile,
+                    inputPaths.paths,
+                    outputTarget.ffmpegPath,
                     parameter
                 ) { time ->
                     // The progressbar for the conversion is calculated based on the
                     // current time of the conversion and the total time of the batches.
                     onProgress(time / fullTime)
                 }.await()
-                return outputFile
+
+                val result = outputTarget.commit()
+                completed = true
+                return result
             } catch (e: MediaConverter.FFmpegException) {
                 continue
+            } finally {
+                if (!completed) {
+                    outputTarget?.abort()
+                }
+                inputPaths?.close()
             }
         }
 
@@ -503,7 +893,7 @@ abstract class BatchesFolder(
                         )
 
                         put(
-                            Media.RELATIVE_PATH,
+                            MediaStore.MediaColumns.RELATIVE_PATH,
                             relativePath,
                         )
                     }
@@ -599,4 +989,3 @@ abstract class BatchesFolder(
         }
     }
 }
-

--- a/app/src/main/java/app/myzel394/alibi/helpers/MediaConverter.kt
+++ b/app/src/main/java/app/myzel394/alibi/helpers/MediaConverter.kt
@@ -73,6 +73,40 @@ data class AudioConcatenator(
 
 class MediaConverter {
     companion object {
+        private const val MAX_FFMPEG_FAILURE_LOG_CHARS = 8000
+        private const val FD_INPUT_PREFIX = "fd:"
+
+        private fun String.tailForLog(): String =
+            takeLast(MAX_FFMPEG_FAILURE_LOG_CHARS)
+
+        private fun String.asFileDescriptorNumber(): Int? {
+            if (!startsWith(FD_INPUT_PREFIX)) {
+                return null
+            }
+
+            return removePrefix(FD_INPUT_PREFIX).toIntOrNull()
+        }
+
+        private fun asConcatFileEntry(inputFile: String): String {
+            val fileDescriptor = inputFile.asFileDescriptorNumber()
+
+            return if (fileDescriptor == null) {
+                "file '$inputFile'"
+            } else {
+                "file 'fd:'\noption fd $fileDescriptor"
+            }
+        }
+
+        private fun asFFmpegOutputFile(outputFile: String): String {
+            val fileDescriptor = outputFile.asFileDescriptorNumber()
+
+            return if (fileDescriptor == null) {
+                outputFile
+            } else {
+                "-fd $fileDescriptor fd:"
+            }
+        }
+
         fun concatenateAudioFiles(
             inputFiles: Iterable<String>,
             outputFile: String,
@@ -111,7 +145,7 @@ class MediaConverter {
                 },
                 {},
                 { statistics ->
-                    onProgress(statistics.time)
+                    onProgress(statistics.time.toInt())
                 }
             )
 
@@ -134,17 +168,17 @@ class MediaConverter {
         ): CompletableDeferred<Unit> {
             val completer = CompletableDeferred<Unit>()
 
-            val listFile = createTempFile(inputFiles.joinToString("\n") { "file '$it'" })
+            val listFile = createTempFile(inputFiles.joinToString("\n") { asConcatFileEntry(it) })
 
             val command =
-                "-protocol_whitelist saf,concat,content,file,subfile" +
+                "-protocol_whitelist saf,concat,content,file,subfile,fd" +
                         " -safe 0" +
                         " -strict normal" +
                         " -f concat" +
                         " -i ${listFile.absolutePath}" +
                         extraCommand +
                         " -y" +
-                        " $outputFile"
+                        " ${asFFmpegOutputFile(outputFile)}"
 
             FFmpegKit.executeAsync(
                 command,
@@ -159,10 +193,11 @@ class MediaConverter {
                         Log.i(
                             "Video Concatenation",
                             String.format(
-                                "Command failed with state %s and rc %s.%s",
+                                "Command failed with state %s and rc %s.%s\n%s",
                                 session.state,
                                 session.returnCode,
                                 session.failStackTrace,
+                                session.allLogsAsString.tailForLog(),
                             )
                         )
 
@@ -171,7 +206,7 @@ class MediaConverter {
                 },
                 {},
                 { statistics ->
-                    onProgress(statistics.time)
+                    onProgress(statistics.time.toInt())
                 }
             )
 

--- a/app/src/main/java/app/myzel394/alibi/helpers/VideoBatchesFolder.kt
+++ b/app/src/main/java/app/myzel394/alibi/helpers/VideoBatchesFolder.kt
@@ -9,6 +9,7 @@ import android.os.ParcelFileDescriptor
 import android.provider.MediaStore
 import androidx.annotation.RequiresApi
 import androidx.documentfile.provider.DocumentFile
+import app.myzel394.alibi.db.RecordingInformation
 import app.myzel394.alibi.helpers.MediaConverter.Companion.concatenateVideoFiles
 import app.myzel394.alibi.ui.MEDIA_SUBFOLDER_NAME
 import app.myzel394.alibi.ui.RECORDER_INTERNAL_SELECTED_VALUE
@@ -17,6 +18,7 @@ import app.myzel394.alibi.ui.VIDEO_RECORDING_BATCHES_SUBFOLDER_NAME
 import com.arthenica.ffmpegkit.FFmpegKitConfig
 import java.io.File
 import java.time.LocalDateTime
+import java.util.UUID
 
 class VideoBatchesFolder(
     override val context: Context,
@@ -38,6 +40,144 @@ class VideoBatchesFolder(
     )
 
     private var customParcelFileDescriptor: ParcelFileDescriptor? = null
+
+    override fun getFFmpegParameters(
+        recording: RecordingInformation,
+        batchCounters: List<Long>,
+    ): Array<String> {
+        return ffmpegParameters.withOutputFormat(recording.fileExtension)
+    }
+
+    private fun Array<String>.withOutputFormat(extension: String): Array<String> =
+        map {
+            "$it -f $extension"
+        }.toTypedArray()
+
+    override fun prepareInputPathsForFFmpeg(extension: String): FFmpegInputPaths {
+        if (type == BatchType.MEDIA && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            // We can't rely on the raw on-disk path here: MediaStore may rewrite leading
+            // dots in our relative path (e.g. `.video_recordings` becomes `_.video_recordings`),
+            // so the file we look up via `Environment.getExternalStoragePublicDirectory(...)`
+            // doesn't exist and `length() == 0` filters every batch out. Open each batch
+            // through its content URI instead and hand FFmpeg the resulting file descriptor.
+            val fileDescriptorPaths = getUriBatchesForFFmpeg().map {
+                openUriPathForFFmpeg(it.uri, "r")
+            }
+            return FFmpegInputPaths(
+                paths = fileDescriptorPaths.map { it.path },
+                closeables = fileDescriptorPaths,
+            )
+        }
+
+        if (type != BatchType.CUSTOM) {
+            return super.prepareInputPathsForFFmpeg(extension)
+        }
+
+        val fileDescriptorPaths = getUriBatchesForFFmpeg().map {
+            openUriPathForFFmpeg(it.uri, "r")
+        }
+
+        return FFmpegInputPaths(
+            paths = fileDescriptorPaths.map { it.path },
+            closeables = fileDescriptorPaths,
+        )
+    }
+
+    override fun prepareOutputTargetForFFmpeg(
+        date: LocalDateTime,
+        extension: String,
+        fileName: String,
+    ): FFmpegOutputTarget {
+        return when (type) {
+            BatchType.CUSTOM -> prepareCustomOutputTarget(
+                extension = extension,
+                fileName = fileName,
+            )
+
+            BatchType.MEDIA ->
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    prepareMediaOutputTarget(
+                        extension = extension,
+                        fileName = fileName,
+                    )
+                } else {
+                    super.prepareOutputTargetForFFmpeg(date, extension, fileName)
+                }
+
+            BatchType.INTERNAL -> super.prepareOutputTargetForFFmpeg(date, extension, fileName)
+        }
+    }
+
+    private fun prepareCustomOutputTarget(
+        extension: String,
+        fileName: String,
+    ): FFmpegOutputTarget {
+        val tempFileName = ".tmp-${UUID.randomUUID()}-$fileName"
+        val folder = customFolder!!
+        val outputFile = folder.createFile(
+            "video/$extension",
+            tempFileName,
+        ) ?: throw MediaConverter.FFmpegException("Unable to create export destination")
+        val outputPath = openUriPathForFFmpeg(outputFile.uri, "rwt")
+
+        return FFmpegOutputTarget(
+            ffmpegPath = outputPath.path,
+            closeable = outputPath,
+            onCommit = {
+                folder.findFile(fileName)?.delete()
+                if (!outputFile.renameTo(fileName)) {
+                    throw MediaConverter.FFmpegException("Unable to publish export destination")
+                }
+
+                (folder.findFile(fileName) ?: outputFile).uri.toString()
+            },
+            onAbort = {
+                outputFile.delete()
+            },
+        )
+    }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private fun prepareMediaOutputTarget(
+        extension: String,
+        fileName: String,
+    ): FFmpegOutputTarget {
+        val tempFileName = "tmp-${UUID.randomUUID()}-$fileName"
+        val mediaUri = createMediaFile(
+            name = tempFileName,
+            mimeType = "video/$extension",
+            relativePath = BASE_SCOPED_STORAGE_RELATIVE_PATH + "/" + MEDIA_SUBFOLDER_NAME,
+            isPending = true,
+        )
+        // Hand FFmpeg an FD into the MediaStore entry instead of a raw filesystem
+        // path: MediaStore stores pending files with a `.pending-<id>-` prefix, so
+        // the path we'd reconstruct from `relativePath + name` doesn't actually
+        // exist on disk. Writing via FD also keeps the ContentResolver as the
+        // single source of truth for the underlying file, so `publishPendingMediaFile`
+        // is guaranteed to publish the bytes FFmpeg just wrote.
+        val outputPath = openUriPathForFFmpeg(mediaUri, "rwt")
+
+        return FFmpegOutputTarget(
+            ffmpegPath = outputPath.path,
+            closeable = outputPath,
+            onCommit = {
+                publishPendingMediaFile(mediaUri, fileName)
+                mediaUri.toString()
+            },
+            onAbort = {
+                context.contentResolver.delete(mediaUri, null, null)
+            },
+        )
+    }
+
+    override fun getBatchCountersForFFmpeg(): List<Long> {
+        if (type == BatchType.MEDIA && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            // Same MediaStore path-rewrite caveat as `prepareInputPathsForFFmpeg`:
+            // and read counters straight from the MediaStore query.
+            return getUriBatchesForFFmpeg().map { it.counter }
+        }
+        return super.getBatchCountersForFFmpeg()
+    }
 
     override fun getOutputFileForFFmpeg(
         date: LocalDateTime,

--- a/app/src/main/java/app/myzel394/alibi/services/AudioRecorderService.kt
+++ b/app/src/main/java/app/myzel394/alibi/services/AudioRecorderService.kt
@@ -307,7 +307,7 @@ class AudioRecorderService :
             folderPath = batchesFolder.exportFolderForSettings(),
             recordingStart = recordingStart,
             maxDuration = settings.maxDuration,
-            batchesAmount = batchesFolder.getBatchesForFFmpeg().size,
+            batchesAmount = batchesFolder.getBatchesAmount(),
             fileExtension = settings.audioRecorderSettings.fileExtension,
             intervalDuration = settings.intervalDuration,
             type = RecordingInformation.Type.AUDIO,

--- a/app/src/main/java/app/myzel394/alibi/services/RecorderService.kt
+++ b/app/src/main/java/app/myzel394/alibi/services/RecorderService.kt
@@ -117,7 +117,8 @@ abstract class RecorderService : LifecycleService() {
             }
         }
 
-        return super.onStartCommand(intent, flags, startId)
+        super.onStartCommand(intent, flags, startId)
+        return START_NOT_STICKY
     }
 
     inner class RecorderBinder : Binder() {

--- a/app/src/main/java/app/myzel394/alibi/services/VideoRecorderService.kt
+++ b/app/src/main/java/app/myzel394/alibi/services/VideoRecorderService.kt
@@ -127,13 +127,20 @@ class VideoRecorderService :
 
         fun action() {
             stopActiveRecording()
+            val recordingCounter = counter
             val newRecording = prepareVideoRecording()
 
             _videoFinalizerListener = CompletableDeferred()
 
             activeRecording = newRecording.start(ContextCompat.getMainExecutor(this)) { event ->
-                if (event is VideoRecordEvent.Finalize && (this@VideoRecorderService.state == RecorderState.STOPPED || this@VideoRecorderService.state == RecorderState.PAUSED)) {
-                    _videoFinalizerListener.complete(Unit)
+                if (event is VideoRecordEvent.Finalize) {
+                    if (event.error in DELETE_RECORDING_ERROR_CODES) {
+                        batchesFolder.deleteRecordings(recordingCounter..recordingCounter)
+                    }
+
+                    if (this@VideoRecorderService.state == RecorderState.STOPPED || this@VideoRecorderService.state == RecorderState.PAUSED) {
+                        _videoFinalizerListener.complete(Unit)
+                    }
                 }
             }
         }
@@ -309,7 +316,7 @@ class VideoRecorderService :
             folderPath = batchesFolder.exportFolderForSettings(),
             recordingStart = recordingStart,
             maxDuration = settings.maxDuration,
-            batchesAmount = batchesFolder.getBatchesForFFmpeg().size,
+            batchesAmount = batchesFolder.getBatchesAmount(),
             fileExtension = settings.videoRecorderSettings.fileExtension,
             intervalDuration = settings.intervalDuration,
             type = RecordingInformation.Type.VIDEO,
@@ -317,6 +324,12 @@ class VideoRecorderService :
 
     companion object {
         const val CAMERA_CLOSE_TIMEOUT = 20000L
+        val DELETE_RECORDING_ERROR_CODES = setOf(
+            VideoRecordEvent.Finalize.ERROR_UNKNOWN,
+            VideoRecordEvent.Finalize.ERROR_RECORDER_ERROR,
+            VideoRecordEvent.Finalize.ERROR_ENCODING_FAILED,
+            VideoRecordEvent.Finalize.ERROR_NO_VALID_DATA,
+        )
     }
 
     class CameraControl(

--- a/app/src/main/java/app/myzel394/alibi/ui/components/RecorderScreen/organisms/RecorderEventsHandler.kt
+++ b/app/src/main/java/app/myzel394/alibi/ui/components/RecorderScreen/organisms/RecorderEventsHandler.kt
@@ -225,8 +225,23 @@ fun RecorderEventsHandler(
                             }
                         }
                     }
+                } catch (error: Error) {
+                    if (
+                        error.cause is UnsatisfiedLinkError ||
+                        error.message?.contains("FFmpegKit failed to start") == true
+                    ) {
+                        Log.e("RecorderEventsHandler", "FFmpegKit failed to save recording", error)
+                        scope.launch {
+                            showRecorderError = true
+                        }
+                    } else {
+                        throw error
+                    }
                 } catch (error: Exception) {
-                    Log.getStackTraceString(error)
+                    Log.e("RecorderEventsHandler", "Failed to save recording", error)
+                    scope.launch {
+                        showRecorderError = true
+                    }
                 } finally {
                     if (recorder.isCurrentlyActivelyRecording) {
                         recorder.recorderService?.unlockFiles(cleanupOldFiles)


### PR DESCRIPTION
The original com.arthenica FFmpegKit artifact no longer resolves from Maven Central, so a clean checkout couldn't even build. Once it did build, the export pipeline silently produced empty files, aborted with "No valid media batches available", or hung on stale SAF handles, depending on storage mode and Android version.

Build:

* Switch app/build.gradle to a maintained fork that keeps the com.arthenica.ffmpegkit API intact, and adapt the few callsites that touched FFmpegKit internals.

Export:

* Drop empty/invalid batches before invoking FFmpeg, and fail fast if no usable inputs remain instead of feeding it an empty concat list.
* Reopen SAF input descriptors for each retry; the previous code reused one PFD across all 17 parameter attempts, so once FFmpeg closed it on the first failure the remaining retries had nothing to read.
* Stage all FFmpeg I/O through ContentResolver-opened file descriptors (`fd:<n>` paths), with Closeable lifetimes tracked by FFmpegInputPaths/FFmpegOutputTarget.
* Fix the MediaStore path-rewrite bug on both sides of the pipeline: MediaStore rewrites relative paths starting with '.' (our '.video_recordings' lives on disk as '_.video_recordings') and prefixes pending files with '.pending-<id>-', so the raw File paths we reconstructed never matched the actual files. Inputs and outputs now go through the MediaStore URI, which is why users were seeing abandoned 'tmp-<UUID>-*' content:// entries with no usable output file.


Code changes by Claude Opus running inside Pi.dev. I built and tested this commit, it works fine in my phone.