### PR TITLE
fix: promote recorder services to foreground during init

### DIFF
--- a/app/src/main/java/app/myzel394/alibi/services/RecorderService.kt
+++ b/app/src/main/java/app/myzel394/alibi/services/RecorderService.kt
@@ -21,6 +21,7 @@ abstract class RecorderService : LifecycleService() {
     private val binder = RecorderBinder()
 
     private var isPaused: Boolean = false
+    private var isForegroundServiceStarted = false
     lateinit var recordingStart: LocalDateTime
         private set
     private lateinit var recordingTimeTimer: ScheduledExecutorService
@@ -56,10 +57,22 @@ abstract class RecorderService : LifecycleService() {
 
     protected abstract fun startForegroundService()
 
+    private fun startForegroundServiceIfNeeded() {
+        if (!isForegroundServiceStarted) {
+            startForegroundService()
+            isForegroundServiceStarted = true
+        }
+    }
+
+    private fun updateForegroundService() {
+        startForegroundService()
+        isForegroundServiceStarted = true
+    }
+
     fun startRecording() {
         recordingStart = LocalDateTime.now()
 
-        startForegroundService()
+        updateForegroundService()
         changeState(RecorderState.RECORDING)
 
         try {
@@ -90,6 +103,7 @@ abstract class RecorderService : LifecycleService() {
         NotificationManagerCompat.from(this)
             .cancel(NotificationHelper.RECORDER_CHANNEL_NOTIFICATION_ID)
         stopForeground(STOP_FOREGROUND_REMOVE)
+        isForegroundServiceStarted = false
         stopSelf()
     }
 
@@ -107,6 +121,7 @@ abstract class RecorderService : LifecycleService() {
                         it
                     )
                 }
+                startForegroundServiceIfNeeded()
             }
 
             "changeState" -> {


### PR DESCRIPTION
Starting a recording could ANR with "Context.startForegroundService() did not then call Service.startForeground()" when camera setup or UI work ran between the startForegroundService() call and the eventual startForeground() invocation, blowing past Android's foreground-service deadline.

Promote the service during the init command, before any of the slow camera/rendering setup, so the deadline is satisfied unconditionally.


Code changes by Claude Opus running inside Pi.dev. I built and tested this commit, it works fine in my phone.
Depends on https://github.com/Myzel394/Alibi/pull/158 to build and run.