### PR TITLE
fix: discard stale recorder services that never received settings

### DIFF
--- a/app/src/main/java/app/myzel394/alibi/services/IntervalRecorderService.kt
+++ b/app/src/main/java/app/myzel394/alibi/services/IntervalRecorderService.kt
@@ -16,6 +16,8 @@ abstract class IntervalRecorderService<I, B : BatchesFolder> :
 
     lateinit var settings: AppSettings
 
+    fun hasInitializedSettings() = ::settings.isInitialized
+
     private lateinit var cycleTimer: ScheduledExecutorService
 
     abstract var batchesFolder: B

--- a/app/src/main/java/app/myzel394/alibi/ui/models/BaseRecorderModel.kt
+++ b/app/src/main/java/app/myzel394/alibi/ui/models/BaseRecorderModel.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
 import android.os.IBinder
+import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -66,39 +67,49 @@ abstract class BaseRecorderModel<I, B : BatchesFolder, T : IntervalRecorderServi
 
     private val connection = object : ServiceConnection {
         override fun onServiceConnected(className: ComponentName, service: IBinder) {
-            recorderService =
-                ((service as RecorderService.RecorderBinder).getService() as T).also { recorder ->
-                    // Init variables from us to the service
-                    recorder.onStateChange = { state ->
-                        recorderState = state
-                    }
-                    recorder.onRecordingTimeChange = { time ->
-                        recordingTime = time
-                    }
-                    recorder.onError = {
-                        onError()
-                    }
-                    recorder.onBatchesFolderNotAccessible = {
-                        onBatchesFolderNotAccessible()
-                    }
+            @Suppress("UNCHECKED_CAST")
+            val recorder = (service as RecorderService.RecorderBinder).getService() as T
 
-                    if (batchesFolder != null) {
-                        recorder.batchesFolder = batchesFolder!!
-                    } else {
-                        batchesFolder = recorder.batchesFolder
-                    }
+            // Init variables from us to the service
+            recorder.onStateChange = { state ->
+                recorderState = state
+            }
+            recorder.onRecordingTimeChange = { time ->
+                recordingTime = time
+            }
+            recorder.onError = {
+                onError()
+            }
+            recorder.onBatchesFolderNotAccessible = {
+                onBatchesFolderNotAccessible()
+            }
 
-                    if (settings != null) {
-                        // If `settings` is set, it means we started the recording, so it should be
-                        // properly set on the service
-                        recorder.settings = settings!!
-                    } else {
-                        settings = recorder.settings
-                    }
+            if (batchesFolder != null) {
+                recorder.batchesFolder = batchesFolder!!
+            } else {
+                batchesFolder = recorder.batchesFolder
+            }
 
-                    // Rest should be initialized from the child class
-                    onServiceConnected(recorder)
-                }
+            if (settings != null) {
+                // If `settings` is set, it means we started the recording, so it should be
+                // properly set on the service
+                recorder.settings = settings!!
+            } else if (recorder.hasInitializedSettings()) {
+                settings = recorder.settings
+            } else {
+                Log.w(
+                    "BaseRecorderModel",
+                    "Connected to recorder service without initialized settings; stopping stale service."
+                )
+                recorder.destroy()
+                reset()
+                return
+            }
+
+            recorderService = recorder
+
+            // Rest should be initialized from the child class
+            onServiceConnected(recorder)
         }
 
         override fun onServiceDisconnected(arg0: ComponentName) {
@@ -164,6 +175,7 @@ abstract class BaseRecorderModel<I, B : BatchesFolder, T : IntervalRecorderServi
         context.bindService(intent, connection, Context.BIND_AUTO_CREATE)
     }
 
+    @Suppress("UNUSED_PARAMETER")
     suspend fun stopRecording(context: Context) {
         recorderService!!.stopRecording()
     }


### PR DESCRIPTION
After a process crash, Android could restart a recorder service and reconnect the UI to it without the model ever calling init() with the saved settings. The very first access to the `settings` lateinit then threw UninitializedPropertyAccessException, crashing the UI as soon as it bound.

Expose `hasInitializedSettings()` on IntervalRecorderService and have BaseRecorderModel detect stale services on bind, drop them, and start a fresh one instead of binding to invalid state.


Code changes by Claude Opus running inside Pi.dev. I built and tested this commit, it works fine in my phone.
Depends on https://github.com/Myzel394/Alibi/pull/158 to build and run.