### PR TITLE
feat: burn time and location overlays into recorded video

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:required="false" />
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <!-- Required for Bluetooth microphones -->
@@ -24,6 +25,7 @@
 
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CAMERA" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
 
@@ -73,7 +75,7 @@
             android:foregroundServiceType="microphone" />
         <service
             android:name=".services.VideoRecorderService"
-            android:foregroundServiceType="camera|microphone" />
+            android:foregroundServiceType="camera|microphone|location" />
 
         <!-- Change locale for Android <= 12 -->
         <service

--- a/app/src/main/java/app/myzel394/alibi/db/AppSettings.kt
+++ b/app/src/main/java/app/myzel394/alibi/db/AppSettings.kt
@@ -450,6 +450,7 @@ data class VideoRecorderSettings(
     val targetedVideoBitRate: Int? = null,
     val quality: String? = null,
     val targetFrameRate: Int? = null,
+    val overlaySettings: VideoOverlaySettings = VideoOverlaySettings.getDefaultInstance(),
 ) {
     fun setTargetedVideoBitRate(bitRate: Int?): VideoRecorderSettings {
         return copy(targetedVideoBitRate = bitRate)
@@ -463,6 +464,10 @@ data class VideoRecorderSettings(
 
     fun setTargetFrameRate(frameRate: Int?): VideoRecorderSettings {
         return copy(targetFrameRate = frameRate)
+    }
+
+    fun setOverlaySettings(overlaySettings: VideoOverlaySettings): VideoRecorderSettings {
+        return copy(overlaySettings = overlaySettings)
     }
 
     fun getQuality(): Quality? =
@@ -530,6 +535,40 @@ data class VideoRecorderSettings(
             null,
         ) + AVAILABLE_QUALITIES
     }
+}
+
+@Serializable
+data class VideoOverlaySettings(
+    val timeEnabled: Boolean = false,
+    val locationEnabled: Boolean = false,
+    val timeFormat: VideoOverlayTimeFormat = VideoOverlayTimeFormat.ISO_OFFSET_DATE_TIME,
+) {
+    val enabled: Boolean
+        get() = timeEnabled || locationEnabled
+
+    fun setTimeEnabled(timeEnabled: Boolean): VideoOverlaySettings {
+        return copy(timeEnabled = timeEnabled)
+    }
+
+    fun setLocationEnabled(locationEnabled: Boolean): VideoOverlaySettings {
+        return copy(locationEnabled = locationEnabled)
+    }
+
+    fun setTimeFormat(timeFormat: VideoOverlayTimeFormat): VideoOverlaySettings {
+        return copy(timeFormat = timeFormat)
+    }
+
+    companion object {
+        fun getDefaultInstance() = VideoOverlaySettings()
+    }
+}
+
+@Serializable
+enum class VideoOverlayTimeFormat {
+    ISO_OFFSET_DATE_TIME,
+    ISO_INSTANT,
+    ISO_LOCAL_DATE_TIME,
+    DASHCAM_DATE_TIME,
 }
 
 @Serializable

--- a/app/src/main/java/app/myzel394/alibi/services/IntervalRecorderService.kt
+++ b/app/src/main/java/app/myzel394/alibi/services/IntervalRecorderService.kt
@@ -16,6 +16,8 @@ abstract class IntervalRecorderService<I, B : BatchesFolder> :
 
     lateinit var settings: AppSettings
 
+    fun hasInitializedSettings() = ::settings.isInitialized
+
     private lateinit var cycleTimer: ScheduledExecutorService
 
     abstract var batchesFolder: B

--- a/app/src/main/java/app/myzel394/alibi/services/VideoRecorderService.kt
+++ b/app/src/main/java/app/myzel394/alibi/services/VideoRecorderService.kt
@@ -1,6 +1,7 @@
 package app.myzel394.alibi.services
 
 import android.annotation.SuppressLint
+import android.Manifest
 import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.os.Build
@@ -8,6 +9,7 @@ import android.util.Range
 import androidx.camera.core.Camera
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.TorchState
+import androidx.camera.core.UseCaseGroup
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.video.FileDescriptorOutputOptions
 import androidx.camera.video.FileOutputOptions
@@ -20,6 +22,7 @@ import androidx.camera.video.VideoCapture
 import androidx.camera.video.VideoRecordEvent
 import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
+import androidx.core.util.Consumer
 import app.myzel394.alibi.NotificationHelper
 import app.myzel394.alibi.db.RecordingInformation
 import app.myzel394.alibi.enums.RecorderState
@@ -27,6 +30,10 @@ import app.myzel394.alibi.helpers.BatchesFolder
 import app.myzel394.alibi.helpers.VideoBatchesFolder
 import app.myzel394.alibi.ui.SUPPORTS_SAVING_VIDEOS_IN_CUSTOM_FOLDERS
 import app.myzel394.alibi.ui.SUPPORTS_SCOPED_STORAGE
+import app.myzel394.alibi.ui.utils.PermissionHelper
+import app.myzel394.alibi.videooverlay.OverlayLocationProvider
+import app.myzel394.alibi.videooverlay.OverlayTextFormatter
+import app.myzel394.alibi.videooverlay.VideoOverlayEffect
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -47,6 +54,8 @@ class VideoRecorderService :
     private var cameraProvider: ProcessCameraProvider? = null
     private var videoCapture: VideoCapture<Recorder>? = null
     private var activeRecording: Recording? = null
+    private var videoOverlayEffect: VideoOverlayEffect? = null
+    private var overlayLocationProvider: OverlayLocationProvider? = null
 
     // Used to listen and check if the camera is available
     private var _cameraAvailableListener = CompletableDeferred<Unit>()
@@ -103,6 +112,13 @@ class VideoRecorderService :
         super.pause()
 
         stopActiveRecording()
+        stopOverlayLocationProvider()
+    }
+
+    override fun resume() {
+        super.resume()
+
+        startOverlayLocationProvider()
     }
 
     override fun startForegroundService() {
@@ -111,14 +127,29 @@ class VideoRecorderService :
             NotificationHelper.RECORDER_CHANNEL_NOTIFICATION_ID,
             getNotificationHelper().buildStartingNotification(),
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                if (enableAudio)
-                    ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
-                else
-                    ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA
+                buildForegroundServiceType()
             } else {
                 0
             },
         )
+    }
+
+    private fun buildForegroundServiceType(): Int {
+        var type = ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA
+
+        if (enableAudio) {
+            type = type or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+        }
+
+        if (
+            hasInitializedSettings() &&
+            settings.videoRecorderSettings.overlaySettings.locationEnabled &&
+            PermissionHelper.hasGranted(this, Manifest.permission.ACCESS_FINE_LOCATION)
+        ) {
+            type = type or ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION
+        }
+
+        return type
     }
 
     @SuppressLint("MissingPermission")
@@ -189,14 +220,23 @@ class VideoRecorderService :
 
         val recorder = buildRecorder()
         videoCapture = buildVideoCapture(recorder)
+        val useCaseGroup = buildUseCaseGroupWithOverlay(videoCapture!!)
 
         runOnMain {
             try {
-                camera = cameraProvider!!.bindToLifecycle(
-                    this,
-                    selectedCamera,
-                    videoCapture
-                )
+                camera = if (useCaseGroup != null) {
+                    cameraProvider!!.bindToLifecycle(
+                        this,
+                        selectedCamera,
+                        useCaseGroup,
+                    )
+                } else {
+                    cameraProvider!!.bindToLifecycle(
+                        this,
+                        selectedCamera,
+                        videoCapture,
+                    )
+                }
 
                 cameraControl = CameraControl(camera!!).also {
                     it.init()
@@ -205,6 +245,7 @@ class VideoRecorderService :
 
                 _cameraAvailableListener.complete(Unit)
             } catch (error: IllegalArgumentException) {
+                releaseOverlay()
                 onError()
             }
         }
@@ -218,6 +259,7 @@ class VideoRecorderService :
             runCatching {
                 cameraProvider?.unbindAll()
             }
+            releaseOverlay()
             _cameraCloserListener.complete(Unit)
 
             // Doesn't need to run on main thread, but
@@ -235,6 +277,62 @@ class VideoRecorderService :
         runCatching {
             activeRecording?.stop()
         }
+    }
+
+    private fun buildUseCaseGroupWithOverlay(
+        videoCapture: VideoCapture<Recorder>,
+    ): UseCaseGroup? {
+        val overlaySettings = settings.videoRecorderSettings.overlaySettings
+        if (!overlaySettings.enabled) {
+            return null
+        }
+
+        val formatter = OverlayTextFormatter()
+        val locationProvider = if (overlaySettings.locationEnabled) {
+            OverlayLocationProvider(this).also {
+                overlayLocationProvider = it
+                it.start()
+            }
+        } else {
+            null
+        }
+
+        videoOverlayEffect = VideoOverlayEffect(
+            overlayTextProvider = {
+                formatter.buildOverlayText(
+                    overlaySettings,
+                    locationProvider?.getLatestLocation(),
+                )
+            },
+            errorListener = Consumer { error ->
+                error.printStackTrace()
+                runOnMain {
+                    releaseOverlay()
+                    onError()
+                }
+            },
+        )
+
+        return UseCaseGroup.Builder()
+            .addUseCase(videoCapture)
+            .addEffect(videoOverlayEffect!!)
+            .build()
+    }
+
+    private fun startOverlayLocationProvider() {
+        overlayLocationProvider?.start()
+    }
+
+    private fun stopOverlayLocationProvider() {
+        overlayLocationProvider?.stop()
+    }
+
+    private fun releaseOverlay() {
+        stopOverlayLocationProvider()
+        overlayLocationProvider = null
+
+        videoOverlayEffect?.release()
+        videoOverlayEffect = null
     }
 
     private fun getNameForMediaFile() =

--- a/app/src/main/java/app/myzel394/alibi/ui/components/RecorderScreen/molecules/VideoRecorderPreparationSheet.kt
+++ b/app/src/main/java/app/myzel394/alibi/ui/components/RecorderScreen/molecules/VideoRecorderPreparationSheet.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.GpsFixed
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -53,6 +54,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.lifecycle.viewmodel.compose.viewModel
 import app.myzel394.alibi.R
+import app.myzel394.alibi.db.AppSettings
 import app.myzel394.alibi.ui.BIG_PRIMARY_BUTTON_SIZE
 import app.myzel394.alibi.ui.SHEET_BOTTOM_OFFSET
 import app.myzel394.alibi.ui.components.RecorderScreen.atoms.CameraPreview
@@ -71,6 +73,7 @@ import kotlin.math.abs
 fun VideoRecorderPreparationSheet(
     showPreview: Boolean,
     videoSettings: VideoRecorderModel,
+    appSettings: AppSettings,
     onDismiss: () -> Unit,
     onPreviewVisible: () -> Unit,
     onPreviewHidden: () -> Unit,
@@ -185,42 +188,60 @@ fun VideoRecorderPreparationSheet(
                             horizontalAlignment = Alignment.CenterHorizontally,
                         ) {
                             PermissionRequester(
-                                permission = Manifest.permission.CAMERA,
-                                icon = Icons.Default.CameraAlt,
+                                permission = Manifest.permission.ACCESS_FINE_LOCATION,
+                                icon = Icons.Default.GpsFixed,
                                 onPermissionAvailable = {
                                     onStartRecording()
-                                }
-                            ) { trigger ->
-                                Row(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .height(BIG_PRIMARY_BUTTON_SIZE)
-                                        .clip(CircleShape)
-                                        .background(MaterialTheme.colorScheme.primary)
-                                        .padding(16.dp)
-                                        .semantics {
-                                            contentDescription = label
-                                        }
-                                        .pointerInput(Unit) {
-                                            detectTapGestures(
-                                                onLongPress = {
-                                                    if (hasGrantedCameraPermission) {
-                                                        onPreviewVisible()
-                                                    }
-                                                },
-                                                onTap = {
-                                                    trigger()
-                                                }
+                                },
+                            ) { triggerLocationPermission ->
+                                PermissionRequester(
+                                    permission = Manifest.permission.CAMERA,
+                                    icon = Icons.Default.CameraAlt,
+                                    onPermissionAvailable = {
+                                        if (
+                                            appSettings.videoRecorderSettings.overlaySettings.locationEnabled &&
+                                            !PermissionHelper.hasGranted(
+                                                context,
+                                                Manifest.permission.ACCESS_FINE_LOCATION,
                                             )
-                                        },
-                                    horizontalArrangement = Arrangement.Center,
-                                    verticalAlignment = Alignment.CenterVertically,
-                                ) {
-                                    Text(
-                                        label,
-                                        style = MaterialTheme.typography.labelLarge,
-                                        color = MaterialTheme.colorScheme.onPrimary,
-                                    )
+                                        ) {
+                                            triggerLocationPermission()
+                                        } else {
+                                            onStartRecording()
+                                        }
+                                    }
+                                ) { trigger ->
+                                    Row(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .height(BIG_PRIMARY_BUTTON_SIZE)
+                                            .clip(CircleShape)
+                                            .background(MaterialTheme.colorScheme.primary)
+                                            .padding(16.dp)
+                                            .semantics {
+                                                contentDescription = label
+                                            }
+                                            .pointerInput(Unit) {
+                                                detectTapGestures(
+                                                    onLongPress = {
+                                                        if (hasGrantedCameraPermission) {
+                                                            onPreviewVisible()
+                                                        }
+                                                    },
+                                                    onTap = {
+                                                        trigger()
+                                                    }
+                                                )
+                                            },
+                                        horizontalArrangement = Arrangement.Center,
+                                        verticalAlignment = Alignment.CenterVertically,
+                                    ) {
+                                        Text(
+                                            label,
+                                            style = MaterialTheme.typography.labelLarge,
+                                            color = MaterialTheme.colorScheme.onPrimary,
+                                        )
+                                    }
                                 }
                             }
 

--- a/app/src/main/java/app/myzel394/alibi/ui/components/RecorderScreen/molecules/VideoRecordingStart.kt
+++ b/app/src/main/java/app/myzel394/alibi/ui/components/RecorderScreen/molecules/VideoRecordingStart.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.InsertDriveFile
 import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.GpsFixed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -39,6 +40,7 @@ fun VideoRecordingStart(
         VideoRecorderPreparationSheet(
             showPreview = showPreview,
             videoSettings = videoRecorder,
+            appSettings = appSettings,
             onDismiss = {
                 showSheet = false
             },
@@ -57,38 +59,56 @@ fun VideoRecordingStart(
             showSheet = true
         }
     ) { triggerExternalStorage ->
-        BigButton(
-            label = stringResource(R.string.ui_videoRecorder_action_start_label),
-            description = stringResource(R.string.ui_videoRecorder_action_configure_label),
-            icon = Icons.Default.CameraAlt,
-            onLongClick = {
-                if (appSettings.requiresExternalStoragePermission(context)) {
-                    triggerExternalStorage()
-                    return@BigButton
-                }
-
-                showSheet = true
+        PermissionRequester(
+            permission = Manifest.permission.ACCESS_FINE_LOCATION,
+            icon = Icons.Default.GpsFixed,
+            onPermissionAvailable = {
+                videoRecorder.startRecording(context, appSettings)
             },
-            onClick = {
-                if (appSettings.requiresExternalStoragePermission(context)) {
-                    triggerExternalStorage()
-                    return@BigButton
-                }
+        ) { triggerLocation ->
+            BigButton(
+                label = stringResource(R.string.ui_videoRecorder_action_start_label),
+                description = stringResource(R.string.ui_videoRecorder_action_configure_label),
+                icon = Icons.Default.CameraAlt,
+                onLongClick = {
+                    if (appSettings.requiresExternalStoragePermission(context)) {
+                        triggerExternalStorage()
+                        return@BigButton
+                    }
 
-                if (PermissionHelper.hasGranted(
-                        context,
-                        Manifest.permission.CAMERA
-                    ) && PermissionHelper.hasGranted(
-                        context,
-                        Manifest.permission.RECORD_AUDIO
-                    )
-                ) {
-                    videoRecorder.startRecording(context, appSettings)
-                } else {
                     showSheet = true
-                }
-            },
-            isBig = useLargeButtons,
-        )
+                },
+                onClick = {
+                    if (appSettings.requiresExternalStoragePermission(context)) {
+                        triggerExternalStorage()
+                        return@BigButton
+                    }
+
+                    if (PermissionHelper.hasGranted(
+                            context,
+                            Manifest.permission.CAMERA
+                        ) && PermissionHelper.hasGranted(
+                            context,
+                            Manifest.permission.RECORD_AUDIO
+                        )
+                    ) {
+                        if (
+                            appSettings.videoRecorderSettings.overlaySettings.locationEnabled &&
+                            !PermissionHelper.hasGranted(
+                                context,
+                                Manifest.permission.ACCESS_FINE_LOCATION,
+                            )
+                        ) {
+                            triggerLocation()
+                        } else {
+                            videoRecorder.startRecording(context, appSettings)
+                        }
+                    } else {
+                        showSheet = true
+                    }
+                },
+                isBig = useLargeButtons,
+            )
+        }
     }
 }

--- a/app/src/main/java/app/myzel394/alibi/ui/components/SettingsScreen/Tiles/VideoRecorderOverlayTile.kt
+++ b/app/src/main/java/app/myzel394/alibi/ui/components/SettingsScreen/Tiles/VideoRecorderOverlayTile.kt
@@ -1,0 +1,176 @@
+package app.myzel394.alibi.ui.components.SettingsScreen.Tiles
+
+import android.Manifest
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccessTime
+import androidx.compose.material.icons.filled.GpsFixed
+import androidx.compose.material.icons.filled.Timelapse
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import app.myzel394.alibi.R
+import app.myzel394.alibi.dataStore
+import app.myzel394.alibi.db.AppSettings
+import app.myzel394.alibi.db.VideoOverlaySettings
+import app.myzel394.alibi.db.VideoOverlayTimeFormat
+import app.myzel394.alibi.ui.components.atoms.PermissionRequester
+import app.myzel394.alibi.ui.components.atoms.SettingsTile
+import app.myzel394.alibi.ui.utils.IconResource
+import com.maxkeppeker.sheets.core.models.base.Header
+import com.maxkeppeker.sheets.core.models.base.IconSource
+import com.maxkeppeker.sheets.core.models.base.rememberUseCaseState
+import com.maxkeppeler.sheets.list.ListDialog
+import com.maxkeppeler.sheets.list.models.ListOption
+import com.maxkeppeler.sheets.list.models.ListSelection
+import kotlinx.coroutines.launch
+
+private val TIME_FORMAT_LABELS = mapOf(
+    VideoOverlayTimeFormat.ISO_OFFSET_DATE_TIME to R.string.ui_settings_option_videoOverlay_timeFormat_isoOffset,
+    VideoOverlayTimeFormat.ISO_INSTANT to R.string.ui_settings_option_videoOverlay_timeFormat_isoInstant,
+    VideoOverlayTimeFormat.ISO_LOCAL_DATE_TIME to R.string.ui_settings_option_videoOverlay_timeFormat_isoLocal,
+    VideoOverlayTimeFormat.DASHCAM_DATE_TIME to R.string.ui_settings_option_videoOverlay_timeFormat_dashcam,
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun VideoRecorderOverlayTile(
+    settings: AppSettings,
+) {
+    val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+    val dataStore = context.dataStore
+    val showTimeFormatDialog = rememberUseCaseState()
+    val overlaySettings = settings.videoRecorderSettings.overlaySettings
+
+    fun updateOverlaySettings(update: (VideoOverlaySettings) -> VideoOverlaySettings) {
+        scope.launch {
+            dataStore.updateData {
+                it.setVideoRecorderSettings(
+                    it.videoRecorderSettings.setOverlaySettings(
+                        update(it.videoRecorderSettings.overlaySettings)
+                    )
+                )
+            }
+        }
+    }
+
+    fun updateTimeFormat(timeFormat: VideoOverlayTimeFormat) {
+        updateOverlaySettings {
+            it.setTimeFormat(timeFormat)
+        }
+    }
+
+    ListDialog(
+        state = showTimeFormatDialog,
+        header = Header.Default(
+            title = stringResource(R.string.ui_settings_option_videoOverlay_timeFormat_title),
+            icon = IconSource(
+                painter = IconResource.fromImageVector(Icons.Default.Timelapse)
+                    .asPainterResource(),
+                contentDescription = null,
+            ),
+        ),
+        selection = ListSelection.Single(
+            showRadioButtons = true,
+            options = VideoOverlayTimeFormat.entries.map { timeFormat ->
+                ListOption(
+                    titleText = stringResource(TIME_FORMAT_LABELS[timeFormat]!!),
+                    selected = overlaySettings.timeFormat == timeFormat,
+                )
+            }
+        ) { index, _ ->
+            updateTimeFormat(VideoOverlayTimeFormat.entries[index])
+        },
+    )
+
+    Column {
+        SettingsTile(
+            title = stringResource(R.string.ui_settings_option_videoOverlay_time_title),
+            description = stringResource(R.string.ui_settings_option_videoOverlay_time_description),
+            leading = {
+                Icon(
+                    Icons.Default.AccessTime,
+                    contentDescription = null,
+                )
+            },
+            trailing = {
+                Switch(
+                    checked = overlaySettings.timeEnabled,
+                    onCheckedChange = { enabled ->
+                        updateOverlaySettings {
+                            it.setTimeEnabled(enabled)
+                        }
+                    },
+                )
+            },
+        )
+
+        if (overlaySettings.timeEnabled) {
+            SettingsTile(
+                title = stringResource(R.string.ui_settings_option_videoOverlay_timeFormat_title),
+                description = stringResource(R.string.ui_settings_option_videoOverlay_timeFormat_description),
+                leading = {
+                    Icon(
+                        Icons.Default.Timelapse,
+                        contentDescription = null,
+                    )
+                },
+                trailing = {
+                    Button(
+                        onClick = showTimeFormatDialog::show,
+                        colors = ButtonDefaults.filledTonalButtonColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        ),
+                        shape = MaterialTheme.shapes.medium,
+                    ) {
+                        Text(stringResource(TIME_FORMAT_LABELS[overlaySettings.timeFormat]!!))
+                    }
+                },
+            )
+        }
+
+        PermissionRequester(
+            permission = Manifest.permission.ACCESS_FINE_LOCATION,
+            icon = Icons.Default.GpsFixed,
+            onPermissionAvailable = {
+                updateOverlaySettings {
+                    it.setLocationEnabled(true)
+                }
+            },
+        ) { triggerLocationPermission ->
+            SettingsTile(
+                title = stringResource(R.string.ui_settings_option_videoOverlay_location_title),
+                description = stringResource(R.string.ui_settings_option_videoOverlay_location_description),
+                leading = {
+                    Icon(
+                        Icons.Default.GpsFixed,
+                        contentDescription = null,
+                    )
+                },
+                trailing = {
+                    Switch(
+                        checked = overlaySettings.locationEnabled,
+                        onCheckedChange = { enabled ->
+                            if (enabled) {
+                                triggerLocationPermission()
+                            } else {
+                                updateOverlaySettings {
+                                    it.setLocationEnabled(false)
+                                }
+                            }
+                        },
+                    )
+                },
+            )
+        }
+    }
+}

--- a/app/src/main/java/app/myzel394/alibi/ui/models/BaseRecorderModel.kt
+++ b/app/src/main/java/app/myzel394/alibi/ui/models/BaseRecorderModel.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
 import android.os.IBinder
+import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -66,39 +67,49 @@ abstract class BaseRecorderModel<I, B : BatchesFolder, T : IntervalRecorderServi
 
     private val connection = object : ServiceConnection {
         override fun onServiceConnected(className: ComponentName, service: IBinder) {
-            recorderService =
-                ((service as RecorderService.RecorderBinder).getService() as T).also { recorder ->
-                    // Init variables from us to the service
-                    recorder.onStateChange = { state ->
-                        recorderState = state
-                    }
-                    recorder.onRecordingTimeChange = { time ->
-                        recordingTime = time
-                    }
-                    recorder.onError = {
-                        onError()
-                    }
-                    recorder.onBatchesFolderNotAccessible = {
-                        onBatchesFolderNotAccessible()
-                    }
+            @Suppress("UNCHECKED_CAST")
+            val recorder = (service as RecorderService.RecorderBinder).getService() as T
 
-                    if (batchesFolder != null) {
-                        recorder.batchesFolder = batchesFolder!!
-                    } else {
-                        batchesFolder = recorder.batchesFolder
-                    }
+            // Init variables from us to the service
+            recorder.onStateChange = { state ->
+                recorderState = state
+            }
+            recorder.onRecordingTimeChange = { time ->
+                recordingTime = time
+            }
+            recorder.onError = {
+                onError()
+            }
+            recorder.onBatchesFolderNotAccessible = {
+                onBatchesFolderNotAccessible()
+            }
 
-                    if (settings != null) {
-                        // If `settings` is set, it means we started the recording, so it should be
-                        // properly set on the service
-                        recorder.settings = settings!!
-                    } else {
-                        settings = recorder.settings
-                    }
+            if (batchesFolder != null) {
+                recorder.batchesFolder = batchesFolder!!
+            } else {
+                batchesFolder = recorder.batchesFolder
+            }
 
-                    // Rest should be initialized from the child class
-                    onServiceConnected(recorder)
-                }
+            if (settings != null) {
+                // If `settings` is set, it means we started the recording, so it should be
+                // properly set on the service
+                recorder.settings = settings!!
+            } else if (recorder.hasInitializedSettings()) {
+                settings = recorder.settings
+            } else {
+                Log.w(
+                    "BaseRecorderModel",
+                    "Connected to recorder service without initialized settings; stopping stale service."
+                )
+                recorder.destroy()
+                reset()
+                return
+            }
+
+            recorderService = recorder
+
+            // Rest should be initialized from the child class
+            onServiceConnected(recorder)
         }
 
         override fun onServiceDisconnected(arg0: ComponentName) {
@@ -164,6 +175,7 @@ abstract class BaseRecorderModel<I, B : BatchesFolder, T : IntervalRecorderServi
         context.bindService(intent, connection, Context.BIND_AUTO_CREATE)
     }
 
+    @Suppress("UNUSED_PARAMETER")
     suspend fun stopRecording(context: Context) {
         recorderService!!.stopRecording()
     }

--- a/app/src/main/java/app/myzel394/alibi/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/app/myzel394/alibi/ui/screens/SettingsScreen.kt
@@ -52,6 +52,7 @@ import app.myzel394.alibi.ui.components.SettingsScreen.Tiles.MaxDurationTile
 import app.myzel394.alibi.ui.components.SettingsScreen.Tiles.SaveFolderTile
 import app.myzel394.alibi.ui.components.SettingsScreen.Tiles.VideoRecorderBitrateTile
 import app.myzel394.alibi.ui.components.SettingsScreen.Tiles.VideoRecorderFrameRateTile
+import app.myzel394.alibi.ui.components.SettingsScreen.Tiles.VideoRecorderOverlayTile
 import app.myzel394.alibi.ui.components.SettingsScreen.Tiles.VideoRecorderQualityTile
 import app.myzel394.alibi.ui.components.SettingsScreen.atoms.InAppLanguagePicker
 import app.myzel394.alibi.ui.components.SettingsScreen.atoms.ThemeSelector
@@ -187,6 +188,7 @@ fun SettingsScreen(
                         VideoRecorderQualityTile(settings = settings)
                         VideoRecorderBitrateTile(settings = settings)
                         VideoRecorderFrameRateTile(settings = settings)
+                        VideoRecorderOverlayTile(settings = settings)
                     }
                     HorizontalDivider(
                         modifier = Modifier

--- a/app/src/main/java/app/myzel394/alibi/videooverlay/OverlayLocationProvider.kt
+++ b/app/src/main/java/app/myzel394/alibi/videooverlay/OverlayLocationProvider.kt
@@ -1,0 +1,92 @@
+package app.myzel394.alibi.videooverlay
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.content.Context
+import android.location.Location
+import android.location.LocationListener
+import android.location.LocationManager
+import android.os.Bundle
+import android.os.Looper
+import app.myzel394.alibi.ui.utils.PermissionHelper
+
+class OverlayLocationProvider(
+    private val context: Context,
+) {
+    @Volatile
+    private var latestLocation: OverlayLocation? = null
+    private var started = false
+
+    private val locationManager =
+        context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+
+    private val listener = object : LocationListener {
+        override fun onLocationChanged(location: Location) {
+            latestLocation = location.toOverlayLocation()
+        }
+
+        @Deprecated("Deprecated in Android framework")
+        override fun onStatusChanged(provider: String?, status: Int, extras: Bundle?) = Unit
+    }
+
+    fun getLatestLocation(): OverlayLocation? = latestLocation
+
+    @SuppressLint("MissingPermission")
+    fun start() {
+        if (started) {
+            return
+        }
+
+        if (!PermissionHelper.hasGranted(context, Manifest.permission.ACCESS_FINE_LOCATION)) {
+            latestLocation = null
+            return
+        }
+
+        started = true
+
+        val providers = listOf(
+            LocationManager.GPS_PROVIDER,
+            LocationManager.NETWORK_PROVIDER,
+        ).filter { provider ->
+            locationManager.allProviders.contains(provider)
+        }
+
+        latestLocation = providers
+            .mapNotNull { provider -> locationManager.getLastKnownLocation(provider) }
+            .maxByOrNull { location -> location.time }
+            ?.toOverlayLocation()
+
+        providers
+            .filter { provider -> locationManager.isProviderEnabled(provider) }
+            .forEach { provider ->
+                locationManager.requestLocationUpdates(
+                    provider,
+                    MIN_UPDATE_TIME_MS,
+                    MIN_UPDATE_DISTANCE_METERS,
+                    listener,
+                    Looper.getMainLooper(),
+                )
+            }
+    }
+
+    fun stop() {
+        if (!started) {
+            return
+        }
+
+        locationManager.removeUpdates(listener)
+        started = false
+    }
+
+    private fun Location.toOverlayLocation(): OverlayLocation {
+        return OverlayLocation(
+            latitude = latitude,
+            longitude = longitude,
+        )
+    }
+
+    companion object {
+        private const val MIN_UPDATE_TIME_MS = 1000L
+        private const val MIN_UPDATE_DISTANCE_METERS = 0f
+    }
+}

--- a/app/src/main/java/app/myzel394/alibi/videooverlay/OverlayTextFormatter.kt
+++ b/app/src/main/java/app/myzel394/alibi/videooverlay/OverlayTextFormatter.kt
@@ -1,0 +1,91 @@
+package app.myzel394.alibi.videooverlay
+
+import app.myzel394.alibi.db.VideoOverlaySettings
+import app.myzel394.alibi.db.VideoOverlayTimeFormat
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+import java.util.Locale
+
+data class OverlayLocation(
+    val latitude: Double,
+    val longitude: Double,
+)
+
+class OverlayTextFormatter(
+    private val clock: Clock = Clock.systemDefaultZone(),
+    private val locale: Locale = Locale.US,
+) {
+    fun buildOverlayText(
+        settings: VideoOverlaySettings,
+        location: OverlayLocation?,
+    ): String {
+        return buildList {
+            if (settings.timeEnabled) {
+                add(formatTime(settings.timeFormat))
+            }
+            if (settings.locationEnabled) {
+                add(formatLocation(location))
+            }
+        }.joinToString("\n")
+    }
+
+    fun formatTime(format: VideoOverlayTimeFormat): String {
+        val instant = clock.instant().truncatedTo(ChronoUnit.SECONDS)
+        val zoneId = clock.zone
+
+        return formatTime(format, instant, zoneId)
+    }
+
+    fun formatTime(
+        format: VideoOverlayTimeFormat,
+        instant: Instant,
+        zoneId: ZoneId,
+    ): String {
+        val truncatedInstant = instant.truncatedTo(ChronoUnit.SECONDS)
+
+        return when (format) {
+            VideoOverlayTimeFormat.ISO_OFFSET_DATE_TIME ->
+                DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(
+                    truncatedInstant.atZone(zoneId).toOffsetDateTime()
+                )
+
+            VideoOverlayTimeFormat.ISO_INSTANT ->
+                DateTimeFormatter.ISO_INSTANT.format(truncatedInstant)
+
+            VideoOverlayTimeFormat.ISO_LOCAL_DATE_TIME ->
+                DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(
+                    LocalDateTime.ofInstant(truncatedInstant, zoneId)
+                )
+
+            VideoOverlayTimeFormat.DASHCAM_DATE_TIME ->
+                DASHCAM_DATE_TIME_FORMATTER.format(
+                    LocalDateTime.ofInstant(truncatedInstant, zoneId)
+                )
+        }
+    }
+
+    fun formatLocation(location: OverlayLocation?): String {
+        if (location == null) {
+            return LOCATION_WAITING_TEXT
+        }
+
+        return String.format(
+            locale,
+            "GPS %.6f, %.6f",
+            location.latitude,
+            location.longitude,
+        )
+    }
+
+    companion object {
+        const val LOCATION_WAITING_TEXT = "GPS waiting"
+        private val DASHCAM_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern(
+            "yyyy-MM-dd HH:mm:ss",
+            Locale.US,
+        )
+    }
+}

--- a/app/src/main/java/app/myzel394/alibi/videooverlay/VideoOverlayEffect.kt
+++ b/app/src/main/java/app/myzel394/alibi/videooverlay/VideoOverlayEffect.kt
@@ -1,0 +1,128 @@
+package app.myzel394.alibi.videooverlay
+
+import android.graphics.SurfaceTexture
+import android.os.Handler
+import android.os.HandlerThread
+import android.view.Surface
+import androidx.camera.core.CameraEffect
+import androidx.camera.core.SurfaceOutput
+import androidx.camera.core.SurfaceProcessor
+import androidx.camera.core.SurfaceRequest
+import androidx.core.util.Consumer
+import app.myzel394.alibi.videooverlay.opengl.OpenGlRenderer
+import java.util.concurrent.Executor
+import java.util.concurrent.atomic.AtomicBoolean
+
+class VideoOverlayEffect(
+    targets: Int,
+    private val surfaceProcessor: VideoOverlaySurfaceProcessor,
+    errorListener: Consumer<Throwable>,
+) : CameraEffect(
+    targets,
+    surfaceProcessor.glExecutor,
+    surfaceProcessor,
+    errorListener,
+) {
+    private val released = AtomicBoolean(false)
+
+    constructor(
+        overlayTextProvider: () -> String,
+        errorListener: Consumer<Throwable>,
+        targets: Int = VIDEO_CAPTURE,
+    ) : this(
+        targets,
+        VideoOverlaySurfaceProcessor(overlayTextProvider, errorListener),
+        errorListener,
+    )
+
+    fun release() {
+        if (released.getAndSet(true)) {
+            return
+        }
+
+        surfaceProcessor.release()
+    }
+}
+
+class VideoOverlaySurfaceProcessor(
+    overlayTextProvider: () -> String,
+    private val errorListener: Consumer<Throwable>,
+) : SurfaceProcessor, SurfaceTexture.OnFrameAvailableListener {
+    private val glThread: HandlerThread = HandlerThread("VideoOverlayGlThread").apply {
+        start()
+    }
+    private val glHandler = Handler(glThread.looper)
+    private val openGlRenderer = OpenGlRenderer(overlayTextProvider)
+    private val texMatrix = FloatArray(16)
+
+    private var inputSurface: InputSurface? = null
+
+    val glExecutor: Executor = Executor { command ->
+        glHandler.post(command)
+    }
+
+    private data class InputSurface(
+        val surfaceTexture: SurfaceTexture,
+        val surface: Surface,
+    ) {
+        fun release() {
+            surfaceTexture.setOnFrameAvailableListener(null)
+            surfaceTexture.release()
+            surface.release()
+        }
+    }
+
+    init {
+        glHandler.post {
+            try {
+                openGlRenderer.init()
+            } catch (error: RuntimeException) {
+                errorListener.accept(error)
+            }
+        }
+    }
+
+    override fun onInputSurface(request: SurfaceRequest) {
+        val surfaceTexture = SurfaceTexture(openGlRenderer.textureId).apply {
+            setOnFrameAvailableListener(this@VideoOverlaySurfaceProcessor, glHandler)
+            setDefaultBufferSize(request.resolution.width, request.resolution.height)
+        }
+        val surface = Surface(surfaceTexture)
+        val newInputSurface = InputSurface(surfaceTexture, surface)
+        inputSurface = newInputSurface
+
+        request.provideSurface(surface, glExecutor) {
+            newInputSurface.release()
+            if (inputSurface == newInputSurface) {
+                inputSurface = null
+            }
+        }
+    }
+
+    override fun onOutputSurface(surfaceOutput: SurfaceOutput) {
+        val surface = surfaceOutput.getSurface(glExecutor) {
+            openGlRenderer.unregister(surfaceOutput)
+            surfaceOutput.close()
+        }
+        openGlRenderer.register(surfaceOutput, surface)
+    }
+
+    override fun onFrameAvailable(surfaceTexture: SurfaceTexture) {
+        try {
+            surfaceTexture.updateTexImage()
+            surfaceTexture.getTransformMatrix(texMatrix)
+            openGlRenderer.draw(surfaceTexture.timestamp, texMatrix)
+        } catch (error: RuntimeException) {
+            errorListener.accept(error)
+        }
+    }
+
+    fun release() {
+        glHandler.post {
+            inputSurface?.release()
+            inputSurface = null
+            openGlRenderer.release()
+            glThread.quitSafely()
+        }
+    }
+}

--- a/app/src/main/java/app/myzel394/alibi/videooverlay/opengl/EglCore.kt
+++ b/app/src/main/java/app/myzel394/alibi/videooverlay/opengl/EglCore.kt
@@ -1,0 +1,149 @@
+package app.myzel394.alibi.videooverlay.opengl
+
+import android.opengl.EGL14
+import android.opengl.EGLConfig
+import android.opengl.EGLContext
+import android.opengl.EGLDisplay
+import android.opengl.EGLExt
+import android.opengl.EGLSurface
+import android.view.Surface
+
+private const val EGL_RECORDABLE_ANDROID = 0x3142
+
+class EglCore {
+    private var display: EGLDisplay = EGL14.EGL_NO_DISPLAY
+    private var config: EGLConfig? = null
+    private var context: EGLContext = EGL14.EGL_NO_CONTEXT
+
+    fun init(sharedContext: EGLContext = EGL14.EGL_NO_CONTEXT) {
+        display = EGL14.eglGetDisplay(EGL14.EGL_DEFAULT_DISPLAY).also {
+            check(it != EGL14.EGL_NO_DISPLAY) {
+                "eglGetDisplay failed: ${EGL14.eglGetError()}"
+            }
+        }
+
+        val version = IntArray(2)
+        check(EGL14.eglInitialize(display, version, 0, version, 1)) {
+            "eglInitialize failed: ${EGL14.eglGetError()}"
+        }
+
+        val attributes = intArrayOf(
+            EGL14.EGL_RED_SIZE, 8,
+            EGL14.EGL_GREEN_SIZE, 8,
+            EGL14.EGL_BLUE_SIZE, 8,
+            EGL14.EGL_ALPHA_SIZE, 8,
+            EGL14.EGL_RENDERABLE_TYPE, EGL14.EGL_OPENGL_ES2_BIT,
+            EGL14.EGL_SURFACE_TYPE, EGL14.EGL_WINDOW_BIT or EGL14.EGL_PBUFFER_BIT,
+            EGL_RECORDABLE_ANDROID, 1,
+            EGL14.EGL_NONE,
+        )
+        val configs = arrayOfNulls<EGLConfig>(1)
+        val numConfigs = IntArray(1)
+        check(
+            EGL14.eglChooseConfig(
+                display,
+                attributes,
+                0,
+                configs,
+                0,
+                configs.size,
+                numConfigs,
+                0,
+            )
+        ) {
+            "eglChooseConfig failed: ${EGL14.eglGetError()}"
+        }
+        config = configs[0]
+
+        val contextAttributes = intArrayOf(
+            EGL14.EGL_CONTEXT_CLIENT_VERSION, 2,
+            EGL14.EGL_NONE,
+        )
+        context = EGL14.eglCreateContext(
+            display,
+            config,
+            sharedContext,
+            contextAttributes,
+            0,
+        ).also {
+            check(it != EGL14.EGL_NO_CONTEXT) {
+                "eglCreateContext failed: ${EGL14.eglGetError()}"
+            }
+        }
+    }
+
+    fun createPbufferSurface(width: Int, height: Int): EGLSurface {
+        val attributes = intArrayOf(
+            EGL14.EGL_WIDTH, width,
+            EGL14.EGL_HEIGHT, height,
+            EGL14.EGL_NONE,
+        )
+
+        return EGL14.eglCreatePbufferSurface(display, config, attributes, 0).also {
+            check(it != EGL14.EGL_NO_SURFACE) {
+                "eglCreatePbufferSurface failed: ${EGL14.eglGetError()}"
+            }
+        }
+    }
+
+    fun createWindowSurface(surface: Surface): EGLSurface {
+        val attributes = intArrayOf(EGL14.EGL_NONE)
+
+        return EGL14.eglCreateWindowSurface(display, config, surface, attributes, 0).also {
+            check(it != EGL14.EGL_NO_SURFACE) {
+                "eglCreateWindowSurface failed: ${EGL14.eglGetError()}"
+            }
+        }
+    }
+
+    fun makeCurrent(surface: EGLSurface) {
+        check(EGL14.eglMakeCurrent(display, surface, surface, context)) {
+            "eglMakeCurrent failed: ${EGL14.eglGetError()}"
+        }
+    }
+
+    fun setPresentationTime(surface: EGLSurface, timestampNs: Long) {
+        check(EGLExt.eglPresentationTimeANDROID(display, surface, timestampNs)) {
+            "eglPresentationTimeANDROID failed: ${EGL14.eglGetError()}"
+        }
+    }
+
+    fun swapBuffers(surface: EGLSurface) {
+        check(EGL14.eglSwapBuffers(display, surface)) {
+            "eglSwapBuffers failed: ${EGL14.eglGetError()}"
+        }
+    }
+
+    fun destroySurface(surface: EGLSurface) {
+        if (surface == EGL14.EGL_NO_SURFACE) {
+            return
+        }
+
+        check(EGL14.eglDestroySurface(display, surface)) {
+            "eglDestroySurface failed: ${EGL14.eglGetError()}"
+        }
+    }
+
+    fun release() {
+        if (display == EGL14.EGL_NO_DISPLAY) {
+            return
+        }
+
+        EGL14.eglMakeCurrent(
+            display,
+            EGL14.EGL_NO_SURFACE,
+            EGL14.EGL_NO_SURFACE,
+            EGL14.EGL_NO_CONTEXT,
+        )
+
+        if (context != EGL14.EGL_NO_CONTEXT) {
+            EGL14.eglDestroyContext(display, context)
+            context = EGL14.EGL_NO_CONTEXT
+        }
+
+        EGL14.eglReleaseThread()
+        EGL14.eglTerminate(display)
+        display = EGL14.EGL_NO_DISPLAY
+        config = null
+    }
+}

--- a/app/src/main/java/app/myzel394/alibi/videooverlay/opengl/OpenGlRenderer.kt
+++ b/app/src/main/java/app/myzel394/alibi/videooverlay/opengl/OpenGlRenderer.kt
@@ -1,0 +1,85 @@
+package app.myzel394.alibi.videooverlay.opengl
+
+import android.opengl.EGL14
+import android.opengl.EGLSurface
+import android.opengl.Matrix
+import android.view.Surface
+import androidx.camera.core.SurfaceOutput
+
+class OpenGlRenderer(
+    overlayTextProvider: () -> String,
+    private val eglCore: EglCore = EglCore(),
+    private val cameraRenderPass: CameraRenderPass = CameraRenderPass(),
+    private val overlayRenderPass: OverlayRenderPass = OverlayRenderPass(overlayTextProvider),
+) {
+    private val surfaceMap = HashMap<SurfaceOutput, EGLSurface>()
+    private val identityMatrix = FloatArray(16).also {
+        Matrix.setIdentityM(it, 0)
+    }
+    private val outputTexMatrix = FloatArray(16)
+    private var tempSurface: EGLSurface = EGL14.EGL_NO_SURFACE
+    private var initialized = false
+
+    val textureId: Int
+        get() = cameraRenderPass.textureId.also {
+            check(it != GL_INVALID) {
+                "OpenGL renderer texture ID is not initialized"
+            }
+        }
+
+    fun init() {
+        if (initialized) {
+            return
+        }
+
+        eglCore.init()
+        tempSurface = eglCore.createPbufferSurface(1, 1)
+        eglCore.makeCurrent(tempSurface)
+
+        cameraRenderPass.init()
+        overlayRenderPass.init()
+        initialized = true
+    }
+
+    fun register(surfaceOutput: SurfaceOutput, surface: Surface) {
+        surfaceMap.getOrPut(surfaceOutput) {
+            eglCore.createWindowSurface(surface)
+        }
+    }
+
+    fun unregister(surfaceOutput: SurfaceOutput) {
+        surfaceMap.remove(surfaceOutput)?.let {
+            eglCore.destroySurface(it)
+        }
+    }
+
+    fun draw(timestampNs: Long, texMatrix: FloatArray) {
+        surfaceMap.forEach { (surfaceOutput, eglSurface) ->
+            eglCore.makeCurrent(eglSurface)
+            surfaceOutput.updateTransformMatrix(outputTexMatrix, texMatrix)
+            cameraRenderPass.draw(outputTexMatrix, identityMatrix, surfaceOutput.size)
+            overlayRenderPass.draw(identityMatrix, identityMatrix, surfaceOutput.size)
+            eglCore.setPresentationTime(eglSurface, timestampNs)
+            eglCore.swapBuffers(eglSurface)
+        }
+    }
+
+    fun release() {
+        if (!initialized) {
+            return
+        }
+
+        surfaceMap.forEach { (surfaceOutput, eglSurface) ->
+            surfaceOutput.close()
+            eglCore.destroySurface(eglSurface)
+        }
+        surfaceMap.clear()
+
+        cameraRenderPass.release()
+        overlayRenderPass.release()
+        eglCore.destroySurface(tempSurface)
+        tempSurface = EGL14.EGL_NO_SURFACE
+        eglCore.release()
+        initialized = false
+    }
+}

--- a/app/src/main/java/app/myzel394/alibi/videooverlay/opengl/RenderPasses.kt
+++ b/app/src/main/java/app/myzel394/alibi/videooverlay/opengl/RenderPasses.kt
@@ -1,0 +1,354 @@
+package app.myzel394.alibi.videooverlay.opengl
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Typeface
+import android.opengl.GLES11Ext
+import android.opengl.GLES20
+import android.opengl.GLUtils
+import android.util.Size
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.FloatBuffer
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+const val GL_INVALID = -1
+
+private const val FLOAT_SIZE_BYTES = 4
+
+private val VERTEX_COORDS = floatArrayOf(
+    -1f, -1f,
+    1f, -1f,
+    -1f, 1f,
+    1f, 1f,
+).toFloatBuffer()
+
+private val TEX_COORDS = floatArrayOf(
+    0f, 0f,
+    1f, 0f,
+    0f, 1f,
+    1f, 1f,
+).toFloatBuffer()
+
+private const val VERTEX_SHADER_SOURCE = """
+attribute vec4 aPosition;
+attribute vec4 aTexCoords;
+uniform mat4 uMvpMatrix;
+uniform mat4 uTexMatrix;
+varying vec2 vTexCoords;
+
+void main() {
+    vTexCoords = (uTexMatrix * aTexCoords).xy;
+    gl_Position = uMvpMatrix * aPosition;
+}
+"""
+
+private const val EXTERNAL_TEXTURE_FRAGMENT_SHADER_SOURCE = """
+#extension GL_OES_EGL_image_external : require
+precision mediump float;
+
+uniform samplerExternalOES uTexture;
+varying vec2 vTexCoords;
+
+void main() {
+    gl_FragColor = texture2D(uTexture, vTexCoords);
+}
+"""
+
+private const val TEXTURE_2D_FRAGMENT_SHADER_SOURCE = """
+precision mediump float;
+
+uniform sampler2D uTexture;
+varying vec2 vTexCoords;
+
+void main() {
+    gl_FragColor = texture2D(uTexture, vec2(vTexCoords.x, 1.0 - vTexCoords.y));
+}
+"""
+
+interface RenderPass {
+    fun init()
+
+    fun release()
+}
+
+class CameraRenderPass(
+    private val program: TextureProgram = TextureProgram(EXTERNAL_TEXTURE_FRAGMENT_SHADER_SOURCE),
+) : RenderPass {
+    var textureId = GL_INVALID
+        private set
+
+    override fun init() {
+        program.init()
+        textureId = createTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES)
+    }
+
+    fun draw(texMatrix: FloatArray, mvpMatrix: FloatArray, surfaceSize: Size) {
+        GLES20.glViewport(0, 0, surfaceSize.width, surfaceSize.height)
+        checkGlError("camera viewport")
+        program.draw(
+            textureTarget = GLES11Ext.GL_TEXTURE_EXTERNAL_OES,
+            textureId = textureId,
+            texMatrix = texMatrix,
+            mvpMatrix = mvpMatrix,
+        )
+    }
+
+    override fun release() {
+        if (textureId != GL_INVALID) {
+            GLES20.glDeleteTextures(1, intArrayOf(textureId), 0)
+            textureId = GL_INVALID
+        }
+        program.release()
+    }
+}
+
+class OverlayRenderPass(
+    private val overlayTextProvider: () -> String,
+    private val program: TextureProgram = TextureProgram(TEXTURE_2D_FRAGMENT_SHADER_SOURCE),
+) : RenderPass {
+    private val paint = Paint().apply {
+        typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+        isAntiAlias = true
+        color = Color.WHITE
+    }
+    private var textureId = GL_INVALID
+    private var bitmap: Bitmap? = null
+    private var lastText: String? = null
+    private var lastSurfaceHeight: Int? = null
+    private var textureDirty = true
+
+    override fun init() {
+        program.init()
+        textureId = createTexture(GLES20.GL_TEXTURE_2D)
+    }
+
+    fun draw(texMatrix: FloatArray, mvpMatrix: FloatArray, surfaceSize: Size) {
+        val text = overlayTextProvider()
+        if (text.isBlank()) {
+            return
+        }
+
+        val overlayBitmap = getBitmap(text, surfaceSize)
+        if (textureDirty) {
+            GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, textureId)
+            checkGlError("bind overlay texture")
+            GLUtils.texImage2D(GLES20.GL_TEXTURE_2D, 0, overlayBitmap, 0)
+            checkGlError("upload overlay texture")
+            textureDirty = false
+        }
+
+        val padding = (surfaceSize.height * 0.02f).roundToInt().coerceAtLeast(12)
+        val maxWidth = (surfaceSize.width - padding * 2).coerceAtLeast(1)
+        val scale = min(1f, maxWidth / overlayBitmap.width.toFloat())
+        val viewportWidth = (overlayBitmap.width * scale).roundToInt().coerceAtLeast(1)
+        val viewportHeight = (overlayBitmap.height * scale).roundToInt().coerceAtLeast(1)
+
+        GLES20.glEnable(GLES20.GL_BLEND)
+        GLES20.glBlendFunc(GLES20.GL_SRC_ALPHA, GLES20.GL_ONE_MINUS_SRC_ALPHA)
+        GLES20.glViewport(padding, padding, viewportWidth, viewportHeight)
+        checkGlError("overlay viewport")
+
+        program.draw(
+            textureTarget = GLES20.GL_TEXTURE_2D,
+            textureId = textureId,
+            texMatrix = texMatrix,
+            mvpMatrix = mvpMatrix,
+        )
+
+        GLES20.glDisable(GLES20.GL_BLEND)
+        checkGlError("disable overlay blend")
+    }
+
+    private fun getBitmap(text: String, surfaceSize: Size): Bitmap {
+        if (text == lastText && lastSurfaceHeight == surfaceSize.height && bitmap != null) {
+            return bitmap!!
+        }
+
+        val textSize = max(18f, surfaceSize.height * 0.035f)
+        paint.textSize = textSize
+        paint.setShadowLayer(max(2f, textSize / 12f), 0f, 0f, Color.BLACK)
+
+        val fontMetrics = paint.fontMetrics
+        val lineHeight = (fontMetrics.descent - fontMetrics.ascent) * 1.15f
+        val innerPadding = (textSize * 0.25f).roundToInt()
+        val lines = text.lines()
+        val width = (
+                lines.maxOf { line -> paint.measureText(line) } + innerPadding * 2
+                ).roundToInt().coerceAtLeast(1)
+        val height = (lineHeight * lines.size + innerPadding * 2).roundToInt().coerceAtLeast(1)
+
+        val newBitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(newBitmap)
+        lines.forEachIndexed { index, line ->
+            val baseline = innerPadding - fontMetrics.ascent + index * lineHeight
+            canvas.drawText(line, innerPadding.toFloat(), baseline, paint)
+        }
+
+        bitmap?.recycle()
+        bitmap = newBitmap
+        lastText = text
+        lastSurfaceHeight = surfaceSize.height
+        textureDirty = true
+
+        return newBitmap
+    }
+
+    override fun release() {
+        if (textureId != GL_INVALID) {
+            GLES20.glDeleteTextures(1, intArrayOf(textureId), 0)
+            textureId = GL_INVALID
+        }
+        bitmap?.recycle()
+        bitmap = null
+        program.release()
+    }
+}
+
+class TextureProgram(
+    private val fragmentShaderSource: String,
+) {
+    private var programId = GL_INVALID
+    private var vertexShaderId = GL_INVALID
+    private var fragmentShaderId = GL_INVALID
+    private var aPosition = GL_INVALID
+    private var aTexCoords = GL_INVALID
+    private var uMvpMatrix = GL_INVALID
+    private var uTexMatrix = GL_INVALID
+    private var uTexture = GL_INVALID
+
+    fun init() {
+        vertexShaderId = loadShader(GLES20.GL_VERTEX_SHADER, VERTEX_SHADER_SOURCE)
+        fragmentShaderId = loadShader(GLES20.GL_FRAGMENT_SHADER, fragmentShaderSource)
+        programId = GLES20.glCreateProgram()
+        check(programId != GL_INVALID) {
+            "glCreateProgram failed"
+        }
+        checkGlError("create program")
+
+        GLES20.glAttachShader(programId, vertexShaderId)
+        GLES20.glAttachShader(programId, fragmentShaderId)
+        GLES20.glLinkProgram(programId)
+        checkProgramLinkStatus(programId)
+
+        aPosition = GLES20.glGetAttribLocation(programId, "aPosition")
+        aTexCoords = GLES20.glGetAttribLocation(programId, "aTexCoords")
+        uMvpMatrix = GLES20.glGetUniformLocation(programId, "uMvpMatrix")
+        uTexMatrix = GLES20.glGetUniformLocation(programId, "uTexMatrix")
+        uTexture = GLES20.glGetUniformLocation(programId, "uTexture")
+        checkGlError("get program locations")
+    }
+
+    fun draw(
+        textureTarget: Int,
+        textureId: Int,
+        texMatrix: FloatArray,
+        mvpMatrix: FloatArray,
+    ) {
+        GLES20.glUseProgram(programId)
+        GLES20.glActiveTexture(GLES20.GL_TEXTURE0)
+        GLES20.glBindTexture(textureTarget, textureId)
+        GLES20.glUniform1i(uTexture, 0)
+        GLES20.glUniformMatrix4fv(uTexMatrix, 1, false, texMatrix, 0)
+        GLES20.glUniformMatrix4fv(uMvpMatrix, 1, false, mvpMatrix, 0)
+        GLES20.glEnableVertexAttribArray(aPosition)
+        GLES20.glVertexAttribPointer(
+            aPosition,
+            2,
+            GLES20.GL_FLOAT,
+            false,
+            0,
+            VERTEX_COORDS,
+        )
+        GLES20.glEnableVertexAttribArray(aTexCoords)
+        GLES20.glVertexAttribPointer(
+            aTexCoords,
+            2,
+            GLES20.GL_FLOAT,
+            false,
+            0,
+            TEX_COORDS,
+        )
+        GLES20.glDrawArrays(GLES20.GL_TRIANGLE_STRIP, 0, 4)
+        GLES20.glDisableVertexAttribArray(aPosition)
+        GLES20.glDisableVertexAttribArray(aTexCoords)
+        GLES20.glBindTexture(textureTarget, 0)
+        GLES20.glUseProgram(0)
+        checkGlError("draw texture")
+    }
+
+    fun release() {
+        if (programId != GL_INVALID) {
+            GLES20.glDeleteProgram(programId)
+            programId = GL_INVALID
+        }
+        if (vertexShaderId != GL_INVALID) {
+            GLES20.glDeleteShader(vertexShaderId)
+            vertexShaderId = GL_INVALID
+        }
+        if (fragmentShaderId != GL_INVALID) {
+            GLES20.glDeleteShader(fragmentShaderId)
+            fragmentShaderId = GL_INVALID
+        }
+    }
+}
+
+private fun createTexture(textureTarget: Int): Int {
+    val textureIds = IntArray(1)
+    GLES20.glGenTextures(1, textureIds, 0)
+    GLES20.glBindTexture(textureTarget, textureIds[0])
+    GLES20.glTexParameteri(textureTarget, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_LINEAR)
+    GLES20.glTexParameteri(textureTarget, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_LINEAR)
+    GLES20.glTexParameteri(textureTarget, GLES20.GL_TEXTURE_WRAP_S, GLES20.GL_CLAMP_TO_EDGE)
+    GLES20.glTexParameteri(textureTarget, GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_CLAMP_TO_EDGE)
+    checkGlError("create texture")
+    return textureIds[0]
+}
+
+private fun loadShader(shaderType: Int, source: String): Int {
+    val shaderId = GLES20.glCreateShader(shaderType)
+    check(shaderId != GL_INVALID) {
+        "glCreateShader failed"
+    }
+    GLES20.glShaderSource(shaderId, source)
+    GLES20.glCompileShader(shaderId)
+    checkShaderCompileStatus(shaderId)
+    return shaderId
+}
+
+private fun checkShaderCompileStatus(shaderId: Int) {
+    val status = IntArray(1)
+    GLES20.glGetShaderiv(shaderId, GLES20.GL_COMPILE_STATUS, status, 0)
+    check(status[0] == GLES20.GL_TRUE) {
+        "Shader compilation failed: ${GLES20.glGetShaderInfoLog(shaderId)}"
+    }
+}
+
+private fun checkProgramLinkStatus(programId: Int) {
+    val status = IntArray(1)
+    GLES20.glGetProgramiv(programId, GLES20.GL_LINK_STATUS, status, 0)
+    check(status[0] == GLES20.GL_TRUE) {
+        "Program linking failed: ${GLES20.glGetProgramInfoLog(programId)}"
+    }
+}
+
+private fun checkGlError(operation: String) {
+    val error = GLES20.glGetError()
+    check(error == GLES20.GL_NO_ERROR) {
+        "$operation failed with GL error $error"
+    }
+}
+
+private fun FloatArray.toFloatBuffer(): FloatBuffer {
+    val buffer = ByteBuffer
+        .allocateDirect(size * FLOAT_SIZE_BYTES)
+        .order(ByteOrder.nativeOrder())
+        .asFloatBuffer()
+    buffer.put(this)
+    buffer.position(0)
+    return buffer
+}

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -219,4 +219,14 @@
     <string name="ui_settings_option_filenameFormat_success">The new format will be used for future recordings</string>
     <string name="ui_settings_option_filenameFormat_action_now_label">Save time</string>
     <string name="ui_settings_option_filenameFormat_action_now_explanation">Use the time you saved the recording</string>
+    <string name="ui_settings_option_videoOverlay_time_title">Show time overlay</string>
+    <string name="ui_settings_option_videoOverlay_time_description">Burn the recording time into video recordings.</string>
+    <string name="ui_settings_option_videoOverlay_location_title">Show GPS coordinates</string>
+    <string name="ui_settings_option_videoOverlay_location_description">Burn GPS coordinates into video recordings. Requires location permission.</string>
+    <string name="ui_settings_option_videoOverlay_timeFormat_title">Time overlay format</string>
+    <string name="ui_settings_option_videoOverlay_timeFormat_description">Choose how the time overlay should be formatted.</string>
+    <string name="ui_settings_option_videoOverlay_timeFormat_isoOffset">ISO offset date-time</string>
+    <string name="ui_settings_option_videoOverlay_timeFormat_isoInstant">ISO instant (UTC)</string>
+    <string name="ui_settings_option_videoOverlay_timeFormat_isoLocal">ISO local date-time</string>
+    <string name="ui_settings_option_videoOverlay_timeFormat_dashcam">Dashcam date-time</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -233,4 +233,14 @@
     <string name="ui_settings_option_filenameFormat_success">The new format will be used for future recordings</string>
     <string name="ui_settings_option_filenameFormat_action_now_label">Save time</string>
     <string name="ui_settings_option_filenameFormat_action_now_explanation">Use the time you saved the recording</string>
+    <string name="ui_settings_option_videoOverlay_time_title">Show time overlay</string>
+    <string name="ui_settings_option_videoOverlay_time_description">Burn the recording time into video recordings.</string>
+    <string name="ui_settings_option_videoOverlay_location_title">Show GPS coordinates</string>
+    <string name="ui_settings_option_videoOverlay_location_description">Burn GPS coordinates into video recordings. Requires location permission.</string>
+    <string name="ui_settings_option_videoOverlay_timeFormat_title">Time overlay format</string>
+    <string name="ui_settings_option_videoOverlay_timeFormat_description">Choose how the time overlay should be formatted.</string>
+    <string name="ui_settings_option_videoOverlay_timeFormat_isoOffset">ISO offset date-time</string>
+    <string name="ui_settings_option_videoOverlay_timeFormat_isoInstant">ISO instant (UTC)</string>
+    <string name="ui_settings_option_videoOverlay_timeFormat_isoLocal">ISO local date-time</string>
+    <string name="ui_settings_option_videoOverlay_timeFormat_dashcam">Dashcam date-time</string>
 </resources>


### PR DESCRIPTION
feat: burn time and location overlays into recorded video

Dashcam users repeatedly asked (upstream issues) for evidence metadata
to be visible inside the recorded video itself, not just as sidecar
data: a wall-clock timestamp, and optionally GPS coordinates.

Add separate, default-off settings for time and location overlays
(with curated timestamp formats and location-permission handling),
and a CameraX video effect that renders the configured overlay via an
OpenGL pass on each frame before it reaches the encoder.


Code changes by Claude Opus running inside Pi.dev. I built and tested this commit, it works fine in my phone.
Depends on #158 to build and run.
Contains #161, should be rebased on it.