### PR TITLE
fix: use positional placeholders in multi-arg strings

### DIFF
--- a/app/src/main/res/values-af/strings.xml
+++ b/app/src/main/res/values-af/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">Continue</string>
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> KB/s</string>
     <string name="form_error_type_notNumber">Please enter a valid number</string>
-    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%s</xliff:g> and <xliff:g name="max">%s</xliff:g></string>
+    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%1$s</xliff:g> and <xliff:g name="max">%2$s</xliff:g></string>
     <string name="form_error_value_mustBeGreaterThan">Please enter a number greater than <xliff:g name="min">%s</xliff:g></string>
     <string name="form_value_selected">Selected: %s</string>
     <string name="a11y_selectValue">Select %s</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">Device Microphone</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">The selected microphone will be activated immediately</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">Microphone disconnected</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%s</xliff:g> once it reconnects.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%2$s</xliff:g> once it reconnects.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">Microphone reconnected</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message"><xliff:g name="name">%s</xliff:g> reconnected! Alibi automatically changed the microphone input to it.</string>
     <string name="ui_settings_option_showAllMicrophones_title">Show hidden microphones</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">Verification required</string>
     <string name="identityVerificationRequired_subtitle">You need to verify your identity to continue</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Custom folders for Video Recordings aren\'t supported by your Android version. Alibi will fallback to the internal folder instead for Video Recordings.</string>
-    <string name="ui_minApiRequired">You will need an Android phone running at least Android %s (API-Level: %s) to use this feature</string>
+    <string name="ui_minApiRequired">You will need an Android phone running at least Android %1$s (API-Level: %2$s) to use this feature</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Select a custom location</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">Use the DCIM folder</string>
     <string name="ui_settings_option_saveFolder_dcimValue">DCIM Folder</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Open selected folder in file manager</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Where are my batches stored?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">To view your batches, open the Files app, go to the internal storage and then you will find your batches in following folders:</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%s\" for audio recordings, \"%s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%1$s\" for audio recordings, \"%2$s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Tap on a folder to open it in the Files app</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Unknown</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">To protect your privacy, Alibi stores its batches into its own private, encrypted storage. This storage is only accessible by Alibi and can\'t be accessed by other apps or by a possible intruder. Once you save the recording, you will be asked where you want to save the recording to.</string>
@@ -200,7 +200,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">You will now be asked to select a folder where Alibi should store the batches. Please select a folder where you have write access to.</string>
     <string name="ui_welcome_timeSettings_values_custom">Custom Duration</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s minutes</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s hour, %s minutes</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s hour, %2$s minutes</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 hour, %s minutes</string>
     <string name="ui_welcome_ready_title">You are ready!</string>
     <string name="ui_welcome_ready_message">You are ready to start using Alibi! Go ahead and try it out!</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">متابعه</string>
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> كيلو بايت/ثانية</string>
     <string name="form_error_type_notNumber">الرجاء إدخال رَقَم صالح</string>
-    <string name="form_error_value_notInRange">الرجاء إدخال رَقَم بين <xliff:g name="min">%s</xliff:g> و <xliff:g name="max">%s</xliff:g></string>
+    <string name="form_error_value_notInRange">الرجاء إدخال رَقَم بين <xliff:g name="min">%1$s</xliff:g> و <xliff:g name="max">%2$s</xliff:g></string>
     <string name="form_error_value_mustBeGreaterThan">الرجاء إدخال رَقَم أكبر من <xliff:g name="min">%s</xliff:g></string>
     <string name="form_value_selected">تم التحديد: %s</string>
     <string name="a11y_selectValue">يختار %s</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">جهاز الميكروفون</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">سيتم تفعيل الميكروفون المحدد على الفور</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">تم فصل الميكروفون</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> تم فصله. سيستخدم Alibi الميكروفون الافتراضي بدلاً من ذلك. سنعود تلقائيًا إلى <xliff:g name="nam">%s</xliff:g> بمجرد إعادة الاتصال.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> تم فصله. سيستخدم Alibi الميكروفون الافتراضي بدلاً من ذلك. سنعود تلقائيًا إلى <xliff:g name="nam">%2$s</xliff:g> بمجرد إعادة الاتصال.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">تم إعادة توصيل الميكروفون</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message"><xliff:g name="name">%s</xliff:g> تم إعادة الاتصال! قام Alibi تلقائيًا بتغيير مدخل الميكروفون إليه.</string>
     <string name="ui_settings_option_showAllMicrophones_title">إظهار الميكروفونات المخفية</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">Verification required</string>
     <string name="identityVerificationRequired_subtitle">You need to verify your identity to continue</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Custom folders for Video Recordings aren\'t supported by your Android version. Alibi will fallback to the internal folder instead for Video Recordings.</string>
-    <string name="ui_minApiRequired">You will need an Android phone running at least Android %s (API-Level: %s) to use this feature</string>
+    <string name="ui_minApiRequired">You will need an Android phone running at least Android %1$s (API-Level: %2$s) to use this feature</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Select a custom location</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">Use the DCIM folder</string>
     <string name="ui_settings_option_saveFolder_dcimValue">DCIM Folder</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Open selected folder in file manager</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Where are my batches stored?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">To view your batches, open the Files app, go to the internal storage and then you will find your batches in following folders:</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%s\" for audio recordings, \"%s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%1$s\" for audio recordings, \"%2$s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Tap on a folder to open it in the Files app</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Unknown</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">To protect your privacy, Alibi stores its batches into its own private, encrypted storage. This storage is only accessible by Alibi and can\'t be accessed by other apps or by a possible intruder. Once you save the recording, you will be asked where you want to save the recording to.</string>
@@ -200,7 +200,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">You will now be asked to select a folder where Alibi should store the batches. Please select a folder where you have write access to.</string>
     <string name="ui_welcome_timeSettings_values_custom">Custom Duration</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s minutes</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s hour, %s minutes</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s hour, %2$s minutes</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 hour, %s minutes</string>
     <string name="ui_welcome_ready_title">You are ready!</string>
     <string name="ui_welcome_ready_message">You are ready to start using Alibi! Go ahead and try it out!</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">Continue</string>
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> KB/s</string>
     <string name="form_error_type_notNumber">Please enter a valid number</string>
-    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%s</xliff:g> and <xliff:g name="max">%s</xliff:g></string>
+    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%1$s</xliff:g> and <xliff:g name="max">%2$s</xliff:g></string>
     <string name="form_error_value_mustBeGreaterThan">Please enter a number greater than <xliff:g name="min">%s</xliff:g></string>
     <string name="form_value_selected">Selected: %s</string>
     <string name="a11y_selectValue">Select %s</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">Device Microphone</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">The selected microphone will be activated immediately</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">Microphone disconnected</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%s</xliff:g> once it reconnects.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%2$s</xliff:g> once it reconnects.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">Microphone reconnected</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message"><xliff:g name="name">%s</xliff:g> reconnected! Alibi automatically changed the microphone input to it.</string>
     <string name="ui_settings_option_showAllMicrophones_title">Show hidden microphones</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">Verification required</string>
     <string name="identityVerificationRequired_subtitle">You need to verify your identity to continue</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Custom folders for Video Recordings aren\'t supported by your Android version. Alibi will fallback to the internal folder instead for Video Recordings.</string>
-    <string name="ui_minApiRequired">You will need an Android phone running at least Android %s (API-Level: %s) to use this feature</string>
+    <string name="ui_minApiRequired">You will need an Android phone running at least Android %1$s (API-Level: %2$s) to use this feature</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Select a custom location</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">Use the DCIM folder</string>
     <string name="ui_settings_option_saveFolder_dcimValue">DCIM Folder</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Open selected folder in file manager</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Where are my batches stored?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">To view your batches, open the Files app, go to the internal storage and then you will find your batches in following folders:</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%s\" for audio recordings, \"%s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%1$s\" for audio recordings, \"%2$s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Tap on a folder to open it in the Files app</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Unknown</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">To protect your privacy, Alibi stores its batches into its own private, encrypted storage. This storage is only accessible by Alibi and can\'t be accessed by other apps or by a possible intruder. Once you save the recording, you will be asked where you want to save the recording to.</string>
@@ -200,7 +200,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">You will now be asked to select a folder where Alibi should store the batches. Please select a folder where you have write access to.</string>
     <string name="ui_welcome_timeSettings_values_custom">Custom Duration</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s minutes</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s hour, %s minutes</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s hour, %2$s minutes</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 hour, %s minutes</string>
     <string name="ui_welcome_ready_title">You are ready!</string>
     <string name="ui_welcome_ready_message">You are ready to start using Alibi! Go ahead and try it out!</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">Continue</string>
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> KB/s</string>
     <string name="form_error_type_notNumber">Please enter a valid number</string>
-    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%s</xliff:g> and <xliff:g name="max">%s</xliff:g></string>
+    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%1$s</xliff:g> and <xliff:g name="max">%2$s</xliff:g></string>
     <string name="form_error_value_mustBeGreaterThan">Please enter a number greater than <xliff:g name="min">%s</xliff:g></string>
     <string name="form_value_selected">Selected: %s</string>
     <string name="a11y_selectValue">Select %s</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">Device Microphone</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">The selected microphone will be activated immediately</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">Microphone disconnected</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%s</xliff:g> once it reconnects.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%2$s</xliff:g> once it reconnects.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">Microphone reconnected</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message"><xliff:g name="name">%s</xliff:g> reconnected! Alibi automatically changed the microphone input to it.</string>
     <string name="ui_settings_option_showAllMicrophones_title">Show hidden microphones</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">Verification required</string>
     <string name="identityVerificationRequired_subtitle">You need to verify your identity to continue</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Custom folders for Video Recordings aren\'t supported by your Android version. Alibi will fallback to the internal folder instead for Video Recordings.</string>
-    <string name="ui_minApiRequired">You will need an Android phone running at least Android %s (API-Level: %s) to use this feature</string>
+    <string name="ui_minApiRequired">You will need an Android phone running at least Android %1$s (API-Level: %2$s) to use this feature</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Select a custom location</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">Use the DCIM folder</string>
     <string name="ui_settings_option_saveFolder_dcimValue">DCIM Folder</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Open selected folder in file manager</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Where are my batches stored?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">To view your batches, open the Files app, go to the internal storage and then you will find your batches in following folders:</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%s\" for audio recordings, \"%s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%1$s\" for audio recordings, \"%2$s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Tap on a folder to open it in the Files app</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Unknown</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">To protect your privacy, Alibi stores its batches into its own private, encrypted storage. This storage is only accessible by Alibi and can\'t be accessed by other apps or by a possible intruder. Once you save the recording, you will be asked where you want to save the recording to.</string>
@@ -200,7 +200,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">You will now be asked to select a folder where Alibi should store the batches. Please select a folder where you have write access to.</string>
     <string name="ui_welcome_timeSettings_values_custom">Custom Duration</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s minutes</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s hour, %s minutes</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s hour, %2$s minutes</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 hour, %s minutes</string>
     <string name="ui_welcome_ready_title">You are ready!</string>
     <string name="ui_welcome_ready_message">You are ready to start using Alibi! Go ahead and try it out!</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">Continue</string>
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> KB/s</string>
     <string name="form_error_type_notNumber">Please enter a valid number</string>
-    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%s</xliff:g> and <xliff:g name="max">%s</xliff:g></string>
+    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%1$s</xliff:g> and <xliff:g name="max">%2$s</xliff:g></string>
     <string name="form_error_value_mustBeGreaterThan">Please enter a number greater than <xliff:g name="min">%s</xliff:g></string>
     <string name="form_value_selected">Selected: %s</string>
     <string name="a11y_selectValue">Select %s</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">Device Microphone</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">The selected microphone will be activated immediately</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">Microphone disconnected</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%s</xliff:g> once it reconnects.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%2$s</xliff:g> once it reconnects.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">Microphone reconnected</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message"><xliff:g name="name">%s</xliff:g> reconnected! Alibi automatically changed the microphone input to it.</string>
     <string name="ui_settings_option_showAllMicrophones_title">Show hidden microphones</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">Verification required</string>
     <string name="identityVerificationRequired_subtitle">You need to verify your identity to continue</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Custom folders for Video Recordings aren\'t supported by your Android version. Alibi will fallback to the internal folder instead for Video Recordings.</string>
-    <string name="ui_minApiRequired">You will need an Android phone running at least Android %s (API-Level: %s) to use this feature</string>
+    <string name="ui_minApiRequired">You will need an Android phone running at least Android %1$s (API-Level: %2$s) to use this feature</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Select a custom location</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">Use the DCIM folder</string>
     <string name="ui_settings_option_saveFolder_dcimValue">DCIM Folder</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Open selected folder in file manager</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Where are my batches stored?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">To view your batches, open the Files app, go to the internal storage and then you will find your batches in following folders:</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%s\" for audio recordings, \"%s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%1$s\" for audio recordings, \"%2$s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Tap on a folder to open it in the Files app</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Unknown</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">To protect your privacy, Alibi stores its batches into its own private, encrypted storage. This storage is only accessible by Alibi and can\'t be accessed by other apps or by a possible intruder. Once you save the recording, you will be asked where you want to save the recording to.</string>
@@ -200,7 +200,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">You will now be asked to select a folder where Alibi should store the batches. Please select a folder where you have write access to.</string>
     <string name="ui_welcome_timeSettings_values_custom">Custom Duration</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s minutes</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s hour, %s minutes</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s hour, %2$s minutes</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 hour, %s minutes</string>
     <string name="ui_welcome_ready_title">You are ready!</string>
     <string name="ui_welcome_ready_message">You are ready to start using Alibi! Go ahead and try it out!</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">Fortsetzten</string>
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> KB/s</string>
     <string name="form_error_type_notNumber">Bitte eine gültige Nummer eingeben</string>
-    <string name="form_error_value_notInRange">Bitte gib eine Nummer zwischen<xliff:g name="min">%s</xliff:g> und <xliff:g name="max">%s</xliff:g>ein</string>
+    <string name="form_error_value_notInRange">Bitte gib eine Nummer zwischen<xliff:g name="min">%1$s</xliff:g> und <xliff:g name="max">%2$s</xliff:g>ein</string>
     <string name="form_error_value_mustBeGreaterThan">Bitte gib eine Zahl größer als <xliff:g name="min">%s</xliff:g> ein</string>
     <string name="form_value_selected">%s ausgewählt</string>
     <string name="a11y_selectValue">Wähle %s</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">Geräte-Mikrofon</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">Das ausgewählte Mikrofon wird sofort aktiviert</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">Mikrofon wurde getrennt</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> wurde getrennt. Alibi wird stattdessen das Standardmikrofon verwenden und automatisch zu <xliff:g name="nam">%s</xliff:g> wechseln, sobald es erneut verbunden wird.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> wurde getrennt. Alibi wird stattdessen das Standardmikrofon verwenden und automatisch zu <xliff:g name="nam">%2$s</xliff:g> wechseln, sobald es erneut verbunden wird.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">Mikrofon erneut verbunden</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message"><xliff:g name="name">%s</xliff:g> wurde wieder verbunden! Alibi hat den Mikrofoneingang automatisch geändert.</string>
     <string name="ui_settings_option_showAllMicrophones_title">Versteckte Mikrofone anzeigen</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">Verifizierung erforderlich</string>
     <string name="identityVerificationRequired_subtitle">Sie müssen Ihre Identität verifizieren, um fortzufahren</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Benutzerdefinierte Ordner für Videoaufnahmen werden von Ihrer Android-Version nicht unterstützt. Alibi wird stattdessen für Videoaufnahmen den internen Ordner nutzen.</string>
-    <string name="ui_minApiRequired">Sie benötigen ein Android-Telefon mit mindestens Android %s (API-Level: %s) um diese Funktion zu nutzen</string>
+    <string name="ui_minApiRequired">Sie benötigen ein Android-Telefon mit mindestens Android %1$s (API-Level: %2$s) um diese Funktion zu nutzen</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Wähle einen eigenen Speicherort</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">DCIM Ordner verwenden</string>
     <string name="ui_settings_option_saveFolder_dcimValue">DCIM Ordner</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Ausgewählten Ordner im Dateimanager öffnen</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Wo werden meine Batches gespeichert?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">Um Ihre Batches zu sehen, öffnen Sie die Datei-App, gehen Sie zum internen Speicher und dann finden Sie Ihre Batches in folgenden Ordnern:</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">Die letzten zusammengeführten Aufnahmen werden in diesen Ordnern gespeichert. Jede Aufnahme erstellt einen Unterordner um die kurzen Stapel in (\"%s\" für Audioaufnahmen, \"%s\" für Videoaufnahmen zu speichern). Um die einzelnen Stapel anzeigen zu können, müssen Sie eventuell versteckte Dateien in der Datei-App aktivieren.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">Die letzten zusammengeführten Aufnahmen werden in diesen Ordnern gespeichert. Jede Aufnahme erstellt einen Unterordner um die kurzen Stapel in (\"%1$s\" für Audioaufnahmen, \"%2$s\" für Videoaufnahmen zu speichern). Um die einzelnen Stapel anzeigen zu können, müssen Sie eventuell versteckte Dateien in der Datei-App aktivieren.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Tippen Sie auf einen Ordner, um ihn in der Datei-App zu öffnen</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Unbekannt</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">Um Ihre Privatsphäre zu schützen, speichert Alibi seine Batches in einem eigenen privaten und verschlüsselten Speicher. Dieser Speicher ist nur für Alibi zugänglich und kann nicht von anderen Apps oder einem möglichen Eindringling aufgerufen werden. Sobald Sie die Aufnahme gespeichert haben, werden Sie gefragt, wohin Sie die Aufnahme speichern möchten.</string>
@@ -200,7 +200,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">Sie werden nun aufgefordert, einen Ordner auszuwählen, in dem Alibi die Batches speichern soll. Bitte wählen Sie einen Ordner, auf den Sie Schreibzugriff haben.</string>
     <string name="ui_welcome_timeSettings_values_custom">Benutzerdefinierte Dauer</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s Minuten</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s Stunde, %s Minuten</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s Stunde, %2$s Minuten</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 Stunde, %s Minuten</string>
     <string name="ui_welcome_ready_title">Sie sind bereit!</string>
     <string name="ui_welcome_ready_message">Du bist bereit, Alibi zu verwenden! Probiere es aus!</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">Continue</string>
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> KB/s</string>
     <string name="form_error_type_notNumber">Please enter a valid number</string>
-    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%s</xliff:g> and <xliff:g name="max">%s</xliff:g></string>
+    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%1$s</xliff:g> and <xliff:g name="max">%2$s</xliff:g></string>
     <string name="form_error_value_mustBeGreaterThan">Please enter a number greater than <xliff:g name="min">%s</xliff:g></string>
     <string name="form_value_selected">Selected: %s</string>
     <string name="a11y_selectValue">Select %s</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">Device Microphone</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">The selected microphone will be activated immediately</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">Microphone disconnected</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%s</xliff:g> once it reconnects.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%2$s</xliff:g> once it reconnects.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">Microphone reconnected</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message"><xliff:g name="name">%s</xliff:g> reconnected! Alibi automatically changed the microphone input to it.</string>
     <string name="ui_settings_option_showAllMicrophones_title">Show hidden microphones</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">Verification required</string>
     <string name="identityVerificationRequired_subtitle">You need to verify your identity to continue</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Custom folders for Video Recordings aren\'t supported by your Android version. Alibi will fallback to the internal folder instead for Video Recordings.</string>
-    <string name="ui_minApiRequired">You will need an Android phone running at least Android %s (API-Level: %s) to use this feature</string>
+    <string name="ui_minApiRequired">You will need an Android phone running at least Android %1$s (API-Level: %2$s) to use this feature</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Select a custom location</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">Use the DCIM folder</string>
     <string name="ui_settings_option_saveFolder_dcimValue">DCIM Folder</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Open selected folder in file manager</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Where are my batches stored?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">To view your batches, open the Files app, go to the internal storage and then you will find your batches in following folders:</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%s\" for audio recordings, \"%s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%1$s\" for audio recordings, \"%2$s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Tap on a folder to open it in the Files app</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Unknown</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">To protect your privacy, Alibi stores its batches into its own private, encrypted storage. This storage is only accessible by Alibi and can\'t be accessed by other apps or by a possible intruder. Once you save the recording, you will be asked where you want to save the recording to.</string>
@@ -200,7 +200,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">You will now be asked to select a folder where Alibi should store the batches. Please select a folder where you have write access to.</string>
     <string name="ui_welcome_timeSettings_values_custom">Custom Duration</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s minutes</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s hour, %s minutes</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s hour, %2$s minutes</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 hour, %s minutes</string>
     <string name="ui_welcome_ready_title">You are ready!</string>
     <string name="ui_welcome_ready_message">You are ready to start using Alibi! Go ahead and try it out!</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">Continue</string>
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> KB/s</string>
     <string name="form_error_type_notNumber">Please enter a valid number</string>
-    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%s</xliff:g> and <xliff:g name="max">%s</xliff:g></string>
+    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%1$s</xliff:g> and <xliff:g name="max">%2$s</xliff:g></string>
     <string name="form_error_value_mustBeGreaterThan">Please enter a number greater than <xliff:g name="min">%s</xliff:g></string>
     <string name="form_value_selected">Selected: %s</string>
     <string name="a11y_selectValue">Select %s</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">Device Microphone</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">The selected microphone will be activated immediately</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">Microphone disconnected</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%s</xliff:g> once it reconnects.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%2$s</xliff:g> once it reconnects.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">Microphone reconnected</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message"><xliff:g name="name">%s</xliff:g> reconnected! Alibi automatically changed the microphone input to it.</string>
     <string name="ui_settings_option_showAllMicrophones_title">Show hidden microphones</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">Verification required</string>
     <string name="identityVerificationRequired_subtitle">You need to verify your identity to continue</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Custom folders for Video Recordings aren\'t supported by your Android version. Alibi will fallback to the internal folder instead for Video Recordings.</string>
-    <string name="ui_minApiRequired">You will need an Android phone running at least Android %s (API-Level: %s) to use this feature</string>
+    <string name="ui_minApiRequired">You will need an Android phone running at least Android %1$s (API-Level: %2$s) to use this feature</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Select a custom location</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">Use the DCIM folder</string>
     <string name="ui_settings_option_saveFolder_dcimValue">DCIM Folder</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Open selected folder in file manager</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Where are my batches stored?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">To view your batches, open the Files app, go to the internal storage and then you will find your batches in following folders:</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%s\" for audio recordings, \"%s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%1$s\" for audio recordings, \"%2$s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Tap on a folder to open it in the Files app</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Unknown</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">To protect your privacy, Alibi stores its batches into its own private, encrypted storage. This storage is only accessible by Alibi and can\'t be accessed by other apps or by a possible intruder. Once you save the recording, you will be asked where you want to save the recording to.</string>
@@ -200,7 +200,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">You will now be asked to select a folder where Alibi should store the batches. Please select a folder where you have write access to.</string>
     <string name="ui_welcome_timeSettings_values_custom">Custom Duration</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s minutes</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s hour, %s minutes</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s hour, %2$s minutes</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 hour, %s minutes</string>
     <string name="ui_welcome_ready_title">You are ready!</string>
     <string name="ui_welcome_ready_message">You are ready to start using Alibi! Go ahead and try it out!</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">Continuar</string>
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> KB/s</string>
     <string name="form_error_type_notNumber">Por favor, introduzca un número válido</string>
-    <string name="form_error_value_notInRange">Por favor, introduzca un número entre <xliff:g name="min">%s</xliff:g> y <xliff:g name="max">%s</xliff:g></string>
+    <string name="form_error_value_notInRange">Por favor, introduzca un número entre <xliff:g name="min">%1$s</xliff:g> y <xliff:g name="max">%2$s</xliff:g></string>
     <string name="form_error_value_mustBeGreaterThan">Introduzca un número mayor que <xliff:g name="min">%s</xliff:g></string>
     <string name="form_value_selected">Seleccionado: %s</string>
     <string name="a11y_selectValue">Select %s</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">Micrófono del dispositivo</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">El micrófono seleccionado se activará inmediatamente</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">Micrófono desconectado</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> desconectado. Alibi usará el micrófono predeterminado en su lugar. Se reactivará <xliff:g name="nam">%s</xliff:g> una vez que se vuelva a conectar.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> desconectado. Alibi usará el micrófono predeterminado en su lugar. Se reactivará <xliff:g name="nam">%2$s</xliff:g> una vez que se vuelva a conectar.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">Micrófono desconectado</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message">¡<xliff:g name="name">%s</xliff:g> reconectado! Alibi cambió automáticamente la entrada del micrófono.</string>
     <string name="ui_settings_option_showAllMicrophones_title">Mostrar micrófonos ocultos</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">Verification required</string>
     <string name="identityVerificationRequired_subtitle">You need to verify your identity to continue</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Custom folders for Video Recordings aren\'t supported by your Android version. Alibi will fallback to the internal folder instead for Video Recordings.</string>
-    <string name="ui_minApiRequired">You will need an Android phone running at least Android %s (API-Level: %s) to use this feature</string>
+    <string name="ui_minApiRequired">You will need an Android phone running at least Android %1$s (API-Level: %2$s) to use this feature</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Select a custom location</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">Use the DCIM folder</string>
     <string name="ui_settings_option_saveFolder_dcimValue">DCIM Folder</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Open selected folder in file manager</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Where are my batches stored?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">To view your batches, open the Files app, go to the internal storage and then you will find your batches in following folders:</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%s\" for audio recordings, \"%s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%1$s\" for audio recordings, \"%2$s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Tap on a folder to open it in the Files app</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Unknown</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">To protect your privacy, Alibi stores its batches into its own private, encrypted storage. This storage is only accessible by Alibi and can\'t be accessed by other apps or by a possible intruder. Once you save the recording, you will be asked where you want to save the recording to.</string>
@@ -200,7 +200,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">You will now be asked to select a folder where Alibi should store the batches. Please select a folder where you have write access to.</string>
     <string name="ui_welcome_timeSettings_values_custom">Custom Duration</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s minutes</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s hour, %s minutes</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s hour, %2$s minutes</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 hour, %s minutes</string>
     <string name="ui_welcome_ready_title">You are ready!</string>
     <string name="ui_welcome_ready_message">You are ready to start using Alibi! Go ahead and try it out!</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">Continue</string>
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> KB/s</string>
     <string name="form_error_type_notNumber">Please enter a valid number</string>
-    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%s</xliff:g> and <xliff:g name="max">%s</xliff:g></string>
+    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%1$s</xliff:g> and <xliff:g name="max">%2$s</xliff:g></string>
     <string name="form_error_value_mustBeGreaterThan">Please enter a number greater than <xliff:g name="min">%s</xliff:g></string>
     <string name="form_value_selected">Selected: %s</string>
     <string name="a11y_selectValue">Select %s</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">Device Microphone</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">The selected microphone will be activated immediately</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">Microphone disconnected</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%s</xliff:g> once it reconnects.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%2$s</xliff:g> once it reconnects.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">Microphone reconnected</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message"><xliff:g name="name">%s</xliff:g> reconnected! Alibi automatically changed the microphone input to it.</string>
     <string name="ui_settings_option_showAllMicrophones_title">Show hidden microphones</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">Verification required</string>
     <string name="identityVerificationRequired_subtitle">You need to verify your identity to continue</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Custom folders for Video Recordings aren\'t supported by your Android version. Alibi will fallback to the internal folder instead for Video Recordings.</string>
-    <string name="ui_minApiRequired">You will need an Android phone running at least Android %s (API-Level: %s) to use this feature</string>
+    <string name="ui_minApiRequired">You will need an Android phone running at least Android %1$s (API-Level: %2$s) to use this feature</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Select a custom location</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">Use the DCIM folder</string>
     <string name="ui_settings_option_saveFolder_dcimValue">DCIM Folder</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Open selected folder in file manager</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Where are my batches stored?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">To view your batches, open the Files app, go to the internal storage and then you will find your batches in following folders:</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%s\" for audio recordings, \"%s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%1$s\" for audio recordings, \"%2$s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Tap on a folder to open it in the Files app</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Unknown</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">To protect your privacy, Alibi stores its batches into its own private, encrypted storage. This storage is only accessible by Alibi and can\'t be accessed by other apps or by a possible intruder. Once you save the recording, you will be asked where you want to save the recording to.</string>
@@ -200,7 +200,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">You will now be asked to select a folder where Alibi should store the batches. Please select a folder where you have write access to.</string>
     <string name="ui_welcome_timeSettings_values_custom">Custom Duration</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s minutes</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s hour, %s minutes</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s hour, %2$s minutes</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 hour, %s minutes</string>
     <string name="ui_welcome_ready_title">You are ready!</string>
     <string name="ui_welcome_ready_message">You are ready to start using Alibi! Go ahead and try it out!</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">Continuer</string>
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> Ko/s</string>
     <string name="form_error_type_notNumber">Veuillez saisir un nombre valide</string>
-    <string name="form_error_value_notInRange">Veuillez saisir un nombre entre <xliff:g name="min">%s</xliff:g> et <xliff:g name="max">%s</xliff:g></string>
+    <string name="form_error_value_notInRange">Veuillez saisir un nombre entre <xliff:g name="min">%1$s</xliff:g> et <xliff:g name="max">%2$s</xliff:g></string>
     <string name="form_error_value_mustBeGreaterThan">Veuillez saisir un nombre supérieur à <xliff:g name="min">%s</xliff:g></string>
     <string name="form_value_selected">Sélectionné : %s</string>
     <string name="a11y_selectValue">Sélectionnez %s</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">Microphone de l\'appareil</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">Le microphone sélectionné sera activé immédiatement</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">Microphone déconnecté</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> déconnecté. Alibi va utiliser le microphone par défaut à la place. Nous retournerons automatiquement à <xliff:g name="nam">%s</xliff:g> une fois qu\'il se reconnectera.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> déconnecté. Alibi va utiliser le microphone par défaut à la place. Nous retournerons automatiquement à <xliff:g name="nam">%2$s</xliff:g> une fois qu\'il se reconnectera.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">Microphone reconnecté</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message"><xliff:g name="name">%s</xliff:g> reconnecté ! Alibi a automatiquement modifié le microphone utilisé pour prendre celui-ci.</string>
     <string name="ui_settings_option_showAllMicrophones_title">Afficher les microphones cachés</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">Vérification requise</string>
     <string name="identityVerificationRequired_subtitle">Vous devez vérifier votre identité pour continuer</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Les dossiers personnalisés pour les enregistrements vidéo ne sont pas pris en charge par votre version Android. Alibi utilisera le dossier interne à la place pour les enregistrements vidéo.</string>
-    <string name="ui_minApiRequired">Vous aurez besoin d\'un téléphone Android fonctionnant au moins sous Android %s (niveau API : %s) pour utiliser cette fonctionnalité</string>
+    <string name="ui_minApiRequired">Vous aurez besoin d\'un téléphone Android fonctionnant au moins sous Android %1$s (niveau API : %2$s) pour utiliser cette fonctionnalité</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Sélectionner un emplacement personnalisé</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">Utiliser le dossier DCIM</string>
     <string name="ui_settings_option_saveFolder_dcimValue">Dossier DCIM</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Ouvrir le dossier sélectionné dans le gestionnaire de fichiers</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Où mes séquences sont-elles stockées ?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">Pour afficher vos séquences, ouvrez votre gestionnaire de fichiers, allez sur le stockage interne et vous trouverez vos séquences dans les dossiers suivants :</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">Les enregistrements assemblés finaux seront enregistrés dans ces dossiers. Chaque enregistrement crée un sous-dossier dans lequel stocker les séquences courtes (\"%s\" pour les enregistrements audio, \"%s\" pour les enregistrements vidéo). Pour voir les séquences individuelement, vous devrez peut-être activer les fichiers cachés dans votre gestionnaire de fichiers.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">Les enregistrements assemblés finaux seront enregistrés dans ces dossiers. Chaque enregistrement crée un sous-dossier dans lequel stocker les séquences courtes (\"%1$s\" pour les enregistrements audio, \"%2$s\" pour les enregistrements vidéo). Pour voir les séquences individuelement, vous devrez peut-être activer les fichiers cachés dans votre gestionnaire de fichiers.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Appuyez sur un dossier pour l\'ouvrir dans votre gestionnaire de fichiers</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Inconnu(e)</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">Pour protéger votre vie privée, Alibi stocke les sequences dans son propre stockage privé et chiffré. Ce stockage est uniquement accessible par Alibi et ne peut pas être accédé par d\'autres applications ou par un intrus éventuel. Une fois que vous aurez enregistré votre enregistrement, on vous demandera dans quel dossier vous souhaitez l\'enregistrer.</string>
@@ -201,7 +201,7 @@ Sinon, essayez de changer le dossier de sauvegarde des séquences dans les param
     <string name="ui_welcome_saveFolder_customFolder_message">Vous allez maintenant être invité à sélectionner le dossier où Alibi sauvegardera les séquences. Veuillez sélectionner un dossier dans lequel vous avez accès en écriture.</string>
     <string name="ui_welcome_timeSettings_values_custom">Durée personnalisée</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s minutes</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s heure et %s minutes</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s heure et %2$s minutes</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 heure et %s minutes</string>
     <string name="ui_welcome_ready_title">Vous êtes prêt !</string>
     <string name="ui_welcome_ready_message">Vous êtes prêt à utiliser Alibi! Allez-y et essayez !</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">Continue</string>
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> KB/s</string>
     <string name="form_error_type_notNumber">Please enter a valid number</string>
-    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%s</xliff:g> and <xliff:g name="max">%s</xliff:g></string>
+    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%1$s</xliff:g> and <xliff:g name="max">%2$s</xliff:g></string>
     <string name="form_error_value_mustBeGreaterThan">Please enter a number greater than <xliff:g name="min">%s</xliff:g></string>
     <string name="form_value_selected">Selected: %s</string>
     <string name="a11y_selectValue">Select %s</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">Device Microphone</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">The selected microphone will be activated immediately</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">Microphone disconnected</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%s</xliff:g> once it reconnects.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%2$s</xliff:g> once it reconnects.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">Microphone reconnected</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message"><xliff:g name="name">%s</xliff:g> reconnected! Alibi automatically changed the microphone input to it.</string>
     <string name="ui_settings_option_showAllMicrophones_title">Show hidden microphones</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">Verification required</string>
     <string name="identityVerificationRequired_subtitle">You need to verify your identity to continue</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Custom folders for Video Recordings aren\'t supported by your Android version. Alibi will fallback to the internal folder instead for Video Recordings.</string>
-    <string name="ui_minApiRequired">You will need an Android phone running at least Android %s (API-Level: %s) to use this feature</string>
+    <string name="ui_minApiRequired">You will need an Android phone running at least Android %1$s (API-Level: %2$s) to use this feature</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Select a custom location</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">Use the DCIM folder</string>
     <string name="ui_settings_option_saveFolder_dcimValue">DCIM Folder</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Open selected folder in file manager</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Where are my batches stored?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">To view your batches, open the Files app, go to the internal storage and then you will find your batches in following folders:</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%s\" for audio recordings, \"%s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%1$s\" for audio recordings, \"%2$s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Tap on a folder to open it in the Files app</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Unknown</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">To protect your privacy, Alibi stores its batches into its own private, encrypted storage. This storage is only accessible by Alibi and can\'t be accessed by other apps or by a possible intruder. Once you save the recording, you will be asked where you want to save the recording to.</string>
@@ -200,7 +200,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">You will now be asked to select a folder where Alibi should store the batches. Please select a folder where you have write access to.</string>
     <string name="ui_welcome_timeSettings_values_custom">Custom Duration</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s minutes</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s hour, %s minutes</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s hour, %2$s minutes</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 hour, %s minutes</string>
     <string name="ui_welcome_ready_title">You are ready!</string>
     <string name="ui_welcome_ready_message">You are ready to start using Alibi! Go ahead and try it out!</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">Continue</string>
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> KB/s</string>
     <string name="form_error_type_notNumber">Please enter a valid number</string>
-    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%s</xliff:g> and <xliff:g name="max">%s</xliff:g></string>
+    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%1$s</xliff:g> and <xliff:g name="max">%2$s</xliff:g></string>
     <string name="form_error_value_mustBeGreaterThan">Please enter a number greater than <xliff:g name="min">%s</xliff:g></string>
     <string name="form_value_selected">Selected: %s</string>
     <string name="a11y_selectValue">Select %s</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">Device Microphone</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">The selected microphone will be activated immediately</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">Microphone disconnected</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%s</xliff:g> once it reconnects.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%2$s</xliff:g> once it reconnects.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">Microphone reconnected</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message"><xliff:g name="name">%s</xliff:g> reconnected! Alibi automatically changed the microphone input to it.</string>
     <string name="ui_settings_option_showAllMicrophones_title">Show hidden microphones</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">Verification required</string>
     <string name="identityVerificationRequired_subtitle">You need to verify your identity to continue</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Custom folders for Video Recordings aren\'t supported by your Android version. Alibi will fallback to the internal folder instead for Video Recordings.</string>
-    <string name="ui_minApiRequired">You will need an Android phone running at least Android %s (API-Level: %s) to use this feature</string>
+    <string name="ui_minApiRequired">You will need an Android phone running at least Android %1$s (API-Level: %2$s) to use this feature</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Select a custom location</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">Use the DCIM folder</string>
     <string name="ui_settings_option_saveFolder_dcimValue">DCIM Folder</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Open selected folder in file manager</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Where are my batches stored?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">To view your batches, open the Files app, go to the internal storage and then you will find your batches in following folders:</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%s\" for audio recordings, \"%s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%1$s\" for audio recordings, \"%2$s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Tap on a folder to open it in the Files app</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Unknown</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">To protect your privacy, Alibi stores its batches into its own private, encrypted storage. This storage is only accessible by Alibi and can\'t be accessed by other apps or by a possible intruder. Once you save the recording, you will be asked where you want to save the recording to.</string>
@@ -200,7 +200,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">You will now be asked to select a folder where Alibi should store the batches. Please select a folder where you have write access to.</string>
     <string name="ui_welcome_timeSettings_values_custom">Custom Duration</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s minutes</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s hour, %s minutes</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s hour, %2$s minutes</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 hour, %s minutes</string>
     <string name="ui_welcome_ready_title">You are ready!</string>
     <string name="ui_welcome_ready_message">You are ready to start using Alibi! Go ahead and try it out!</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">Continua</string>
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> KB/s</string>
     <string name="form_error_type_notNumber">Si prega d\'inserire un numero valido</string>
-    <string name="form_error_value_notInRange">Si prega d\'inserire un numero tra <xliff:g name="min">%s</xliff:g> e <xliff:g name="max">%s</xliff:g></string>
+    <string name="form_error_value_notInRange">Si prega d\'inserire un numero tra <xliff:g name="min">%1$s</xliff:g> e <xliff:g name="max">%2$s</xliff:g></string>
     <string name="form_error_value_mustBeGreaterThan">Si prega d\'inserire un numero maggiore di <xliff:g name="min">%s</xliff:g></string>
     <string name="form_value_selected">Selezionati: %s</string>
     <string name="a11y_selectValue">Seleziona %s</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">Microfono Del Dispositivo</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">Il microfono selezionato verrà attivato immediatamente</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">Microfono disconnesso</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> disconnesso. Alibi userà invece il microfono predefinito. Torneremo automaticamente a <xliff:g name="nam">%s</xliff:g> una volta che si ricollega.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> disconnesso. Alibi userà invece il microfono predefinito. Torneremo automaticamente a <xliff:g name="nam">%2$s</xliff:g> una volta che si ricollega.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">Microfono riconnesso</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message"><xliff:g name="name">%s</xliff:g> riconnesso! Alibi ha cambiato automaticamente l\'entrata del microfono.</string>
     <string name="ui_settings_option_showAllMicrophones_title">Mostra microfoni nascosti</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">Verifica necessaria</string>
     <string name="identityVerificationRequired_subtitle">Devi verificare la tua identità per continuare</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Le cartelle personalizzate per le registrazioni video non sono supportate dalla tua versione Android. Alibi passerà alla cartella interna invece per le registrazioni video.</string>
-    <string name="ui_minApiRequired">Avrai bisogno di un telefono Android con almeno Android %s (livello API: %s) per utilizzare questa funzione</string>
+    <string name="ui_minApiRequired">Avrai bisogno di un telefono Android con almeno Android %1$s (livello API: %2$s) per utilizzare questa funzione</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Seleziona una posizione personalizzata</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">Usa la cartella DCIM</string>
     <string name="ui_settings_option_saveFolder_dcimValue">Cartella DCIM</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Apri la cartella selezionata nel file manager</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Dove sono conservati i miei batch?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">Per visualizzare i tuoi batch, apri l\'app File, vai alla memoria interna e poi troverai i tuoi batch nelle seguenti cartelle:</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">Le registrazioni unite finali saranno salvate in quelle cartelle. Ogni registrazione crea una sottocartella per memorizzare i brevi batch in (\"%s\" per le registrazioni audio, \"%s\" per le registrazioni video). Per visualizzare i singoli batch, potrebbe essere necessario abilitare i file nascosti nell\'app File.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">Le registrazioni unite finali saranno salvate in quelle cartelle. Ogni registrazione crea una sottocartella per memorizzare i brevi batch in (\"%1$s\" per le registrazioni audio, \"%2$s\" per le registrazioni video). Per visualizzare i singoli batch, potrebbe essere necessario abilitare i file nascosti nell\'app File.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Tocca una cartella per aprirla nell\'app File</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Sconosciuto</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">Per proteggere la tua privacy, Alibi memorizza i suoi batch nella propria archiviazione privata e cifrata. Questo archivio è accessibile solo da Alibi e non può essere accessibile da altre app o da un possibile intruso. Una volta salvata la registrazione, ti verrà chiesto dove vuoi salvare la registrazione.</string>
@@ -200,7 +200,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">Ora ti verrà chiesto di selezionare una cartella in cui Alibi dovrebbe memorizzare i batch. Seleziona una cartella in cui hai accesso in scrittura.</string>
     <string name="ui_welcome_timeSettings_values_custom">Durata Personalizzata</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s minuti</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s ore %s minuti</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s ore %2$s minuti</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 ora, %s minuti</string>
     <string name="ui_welcome_ready_title">Sei pronto!</string>
     <string name="ui_welcome_ready_message">Sei pronto per iniziare a usare Alibi! Vai avanti e prova!</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">Continue</string>
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> KB/s</string>
     <string name="form_error_type_notNumber">Please enter a valid number</string>
-    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%s</xliff:g> and <xliff:g name="max">%s</xliff:g></string>
+    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%1$s</xliff:g> and <xliff:g name="max">%2$s</xliff:g></string>
     <string name="form_error_value_mustBeGreaterThan">Please enter a number greater than <xliff:g name="min">%s</xliff:g></string>
     <string name="form_value_selected">Selected: %s</string>
     <string name="a11y_selectValue">Select %s</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">Device Microphone</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">The selected microphone will be activated immediately</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">Microphone disconnected</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%s</xliff:g> once it reconnects.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%2$s</xliff:g> once it reconnects.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">Microphone reconnected</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message"><xliff:g name="name">%s</xliff:g> reconnected! Alibi automatically changed the microphone input to it.</string>
     <string name="ui_settings_option_showAllMicrophones_title">Show hidden microphones</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">Verification required</string>
     <string name="identityVerificationRequired_subtitle">You need to verify your identity to continue</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Custom folders for Video Recordings aren\'t supported by your Android version. Alibi will fallback to the internal folder instead for Video Recordings.</string>
-    <string name="ui_minApiRequired">You will need an Android phone running at least Android %s (API-Level: %s) to use this feature</string>
+    <string name="ui_minApiRequired">You will need an Android phone running at least Android %1$s (API-Level: %2$s) to use this feature</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Select a custom location</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">Use the DCIM folder</string>
     <string name="ui_settings_option_saveFolder_dcimValue">DCIM Folder</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Open selected folder in file manager</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Where are my batches stored?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">To view your batches, open the Files app, go to the internal storage and then you will find your batches in following folders:</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%s\" for audio recordings, \"%s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%1$s\" for audio recordings, \"%2$s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Tap on a folder to open it in the Files app</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Unknown</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">To protect your privacy, Alibi stores its batches into its own private, encrypted storage. This storage is only accessible by Alibi and can\'t be accessed by other apps or by a possible intruder. Once you save the recording, you will be asked where you want to save the recording to.</string>
@@ -200,7 +200,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">You will now be asked to select a folder where Alibi should store the batches. Please select a folder where you have write access to.</string>
     <string name="ui_welcome_timeSettings_values_custom">Custom Duration</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s minutes</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s hour, %s minutes</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s hour, %2$s minutes</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 hour, %s minutes</string>
     <string name="ui_welcome_ready_title">You are ready!</string>
     <string name="ui_welcome_ready_message">You are ready to start using Alibi! Go ahead and try it out!</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">Continue</string>
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> KB/s</string>
     <string name="form_error_type_notNumber">Please enter a valid number</string>
-    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%s</xliff:g> and <xliff:g name="max">%s</xliff:g></string>
+    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%1$s</xliff:g> and <xliff:g name="max">%2$s</xliff:g></string>
     <string name="form_error_value_mustBeGreaterThan">Please enter a number greater than <xliff:g name="min">%s</xliff:g></string>
     <string name="form_value_selected">Selected: %s</string>
     <string name="a11y_selectValue">Select %s</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">Device Microphone</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">The selected microphone will be activated immediately</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">Microphone disconnected</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%s</xliff:g> once it reconnects.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%2$s</xliff:g> once it reconnects.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">Microphone reconnected</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message"><xliff:g name="name">%s</xliff:g> reconnected! Alibi automatically changed the microphone input to it.</string>
     <string name="ui_settings_option_showAllMicrophones_title">Show hidden microphones</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">Verification required</string>
     <string name="identityVerificationRequired_subtitle">You need to verify your identity to continue</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Custom folders for Video Recordings aren\'t supported by your Android version. Alibi will fallback to the internal folder instead for Video Recordings.</string>
-    <string name="ui_minApiRequired">You will need an Android phone running at least Android %s (API-Level: %s) to use this feature</string>
+    <string name="ui_minApiRequired">You will need an Android phone running at least Android %1$s (API-Level: %2$s) to use this feature</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Select a custom location</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">Use the DCIM folder</string>
     <string name="ui_settings_option_saveFolder_dcimValue">DCIM Folder</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Open selected folder in file manager</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Where are my batches stored?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">To view your batches, open the Files app, go to the internal storage and then you will find your batches in following folders:</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%s\" for audio recordings, \"%s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%1$s\" for audio recordings, \"%2$s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Tap on a folder to open it in the Files app</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Unknown</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">To protect your privacy, Alibi stores its batches into its own private, encrypted storage. This storage is only accessible by Alibi and can\'t be accessed by other apps or by a possible intruder. Once you save the recording, you will be asked where you want to save the recording to.</string>
@@ -200,7 +200,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">You will now be asked to select a folder where Alibi should store the batches. Please select a folder where you have write access to.</string>
     <string name="ui_welcome_timeSettings_values_custom">Custom Duration</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s minutes</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s hour, %s minutes</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s hour, %2$s minutes</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 hour, %s minutes</string>
     <string name="ui_welcome_ready_title">You are ready!</string>
     <string name="ui_welcome_ready_message">You are ready to start using Alibi! Go ahead and try it out!</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">Verder</string>
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> KB/s</string>
     <string name="form_error_type_notNumber">Geef een geldig nummer op</string>
-    <string name="form_error_value_notInRange">Geef een nummer tussen <xliff:g name="min">%s</xliff:g> en <xliff:g name="max">%s</xliff:g> op</string>
+    <string name="form_error_value_notInRange">Geef een nummer tussen <xliff:g name="min">%1$s</xliff:g> en <xliff:g name="max">%2$s</xliff:g> op</string>
     <string name="form_error_value_mustBeGreaterThan">Geef een nummer groter dan <xliff:g name="min">%s</xliff:g> op</string>
     <string name="form_value_selected">Geselecteerd: %s</string>
     <string name="a11y_selectValue">Selecteer %s</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">Apparaatsmircofoon</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">De geselecteerde microfoon wordt gelijk ingeschakeld</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">Microfoon losgekoppeld</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> losgekoppeld. Alibi zal de standaardmicrofoon gebruiken. We zullen automatisch terugschakelen naar <xliff:g name="nam">%s</xliff:g> zodra het herkoppelt.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> losgekoppeld. Alibi zal de standaardmicrofoon gebruiken. We zullen automatisch terugschakelen naar <xliff:g name="nam">%2$s</xliff:g> zodra het herkoppelt.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">Microfoon herkoppeld</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message"><xliff:g name="name">%s</xliff:g> herkoppeld! Alibi heeft er de microfooninvoer automatisch naar geschakeld.</string>
     <string name="ui_settings_option_showAllMicrophones_title">Verborgen microfoons weergeven</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">Verificatie vereist</string>
     <string name="identityVerificationRequired_subtitle">Verifieer uw identiteit om door te kunnen gaan</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Aangepaste mappen voor video-opnames zijn niet ondersteund door uw Android-versie. Alibi zal in plaats daarvan de interne map gebruiken voor video-opnames.</string>
-    <string name="ui_minApiRequired">U heeft een Android telefoon met minstens Android %s (API-Level: %s) nodig om deze feature te gebruiken</string>
+    <string name="ui_minApiRequired">U heeft een Android telefoon met minstens Android %1$s (API-Level: %2$s) nodig om deze feature te gebruiken</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Een aangepaste locatie selecteren</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">De DCIM map gebruiken</string>
     <string name="ui_settings_option_saveFolder_dcimValue">DCIM map</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Open de geselecteerde map in bestandsbeheer</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Waar zijn mijn batches opgeslagen?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">Om uw batches te bekijken, open de bestandsbeheerder, ga naar interne opslag en daar zult u uw batches vinden in de volgende mappen:</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">De laatste samengevoegde opnames zullen in die mappen worden opslagen. Elke opname maakt een submap aan om erin de korte batches op te slaan (\"%s\" voor audio-opnames, \"%s\" voor video-opnames). Om individuele batches te bekijken, moet u mogelijk verborgen bestanden in de bestandsbeheerder in te schakelen.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">De laatste samengevoegde opnames zullen in die mappen worden opslagen. Elke opname maakt een submap aan om erin de korte batches op te slaan (\"%1$s\" voor audio-opnames, \"%2$s\" voor video-opnames). Om individuele batches te bekijken, moet u mogelijk verborgen bestanden in de bestandsbeheerder in te schakelen.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Tik op een map om hem te openen in de Bestandsbeheerder</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Onbekend</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">Om uw privacy te beschermen, slaat Alibi de batches in zijn eigen privé, versleutelde opslag. Deze opslag is alleen toegankelijk voor Alibi en niet voor andere apps of voor een mogelijke indringer. Zodra u de opname opslaat, wordt u gevraagd waarin u de opnames wilt opslaan.</string>
@@ -200,7 +200,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">U wordt nu gevraagd om een map te selecteren waarin Alibi de batches moet opslaan. Selecteer een map waar u toegang toe heeft.</string>
     <string name="ui_welcome_timeSettings_values_custom">Aangepaste Duur</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s minuten</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s uur, %s minuten</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s uur, %2$s minuten</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 uur, %s minuten</string>
     <string name="ui_welcome_ready_title">U bent gereed!</string>
     <string name="ui_welcome_ready_message">U bent gereed om Alibi te gebruiken! Probeer het eens!</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">Continue</string>
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> KB/s</string>
     <string name="form_error_type_notNumber">Please enter a valid number</string>
-    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%s</xliff:g> and <xliff:g name="max">%s</xliff:g></string>
+    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%1$s</xliff:g> and <xliff:g name="max">%2$s</xliff:g></string>
     <string name="form_error_value_mustBeGreaterThan">Please enter a number greater than <xliff:g name="min">%s</xliff:g></string>
     <string name="form_value_selected">Selected: %s</string>
     <string name="a11y_selectValue">Select %s</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">Device Microphone</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">The selected microphone will be activated immediately</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">Microphone disconnected</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%s</xliff:g> once it reconnects.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%2$s</xliff:g> once it reconnects.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">Microphone reconnected</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message"><xliff:g name="name">%s</xliff:g> reconnected! Alibi automatically changed the microphone input to it.</string>
     <string name="ui_settings_option_showAllMicrophones_title">Show hidden microphones</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">Verification required</string>
     <string name="identityVerificationRequired_subtitle">You need to verify your identity to continue</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Custom folders for Video Recordings aren\'t supported by your Android version. Alibi will fallback to the internal folder instead for Video Recordings.</string>
-    <string name="ui_minApiRequired">You will need an Android phone running at least Android %s (API-Level: %s) to use this feature</string>
+    <string name="ui_minApiRequired">You will need an Android phone running at least Android %1$s (API-Level: %2$s) to use this feature</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Select a custom location</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">Use the DCIM folder</string>
     <string name="ui_settings_option_saveFolder_dcimValue">DCIM Folder</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Open selected folder in file manager</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Where are my batches stored?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">To view your batches, open the Files app, go to the internal storage and then you will find your batches in following folders:</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%s\" for audio recordings, \"%s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%1$s\" for audio recordings, \"%2$s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Tap on a folder to open it in the Files app</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Unknown</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">To protect your privacy, Alibi stores its batches into its own private, encrypted storage. This storage is only accessible by Alibi and can\'t be accessed by other apps or by a possible intruder. Once you save the recording, you will be asked where you want to save the recording to.</string>
@@ -200,7 +200,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">You will now be asked to select a folder where Alibi should store the batches. Please select a folder where you have write access to.</string>
     <string name="ui_welcome_timeSettings_values_custom">Custom Duration</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s minutes</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s hour, %s minutes</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s hour, %2$s minutes</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 hour, %s minutes</string>
     <string name="ui_welcome_ready_title">You are ready!</string>
     <string name="ui_welcome_ready_message">You are ready to start using Alibi! Go ahead and try it out!</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">Continue</string>
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> KB/s</string>
     <string name="form_error_type_notNumber">Please enter a valid number</string>
-    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%s</xliff:g> and <xliff:g name="max">%s</xliff:g></string>
+    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%1$s</xliff:g> and <xliff:g name="max">%2$s</xliff:g></string>
     <string name="form_error_value_mustBeGreaterThan">Please enter a number greater than <xliff:g name="min">%s</xliff:g></string>
     <string name="form_value_selected">Selected: %s</string>
     <string name="a11y_selectValue">Select %s</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">Device Microphone</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">The selected microphone will be activated immediately</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">Microphone disconnected</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%s</xliff:g> once it reconnects.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%2$s</xliff:g> once it reconnects.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">Microphone reconnected</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message"><xliff:g name="name">%s</xliff:g> reconnected! Alibi automatically changed the microphone input to it.</string>
     <string name="ui_settings_option_showAllMicrophones_title">Show hidden microphones</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">Verification required</string>
     <string name="identityVerificationRequired_subtitle">You need to verify your identity to continue</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Custom folders for Video Recordings aren\'t supported by your Android version. Alibi will fallback to the internal folder instead for Video Recordings.</string>
-    <string name="ui_minApiRequired">You will need an Android phone running at least Android %s (API-Level: %s) to use this feature</string>
+    <string name="ui_minApiRequired">You will need an Android phone running at least Android %1$s (API-Level: %2$s) to use this feature</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Select a custom location</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">Use the DCIM folder</string>
     <string name="ui_settings_option_saveFolder_dcimValue">DCIM Folder</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Open selected folder in file manager</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Where are my batches stored?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">To view your batches, open the Files app, go to the internal storage and then you will find your batches in following folders:</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%s\" for audio recordings, \"%s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%1$s\" for audio recordings, \"%2$s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Tap on a folder to open it in the Files app</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Unknown</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">To protect your privacy, Alibi stores its batches into its own private, encrypted storage. This storage is only accessible by Alibi and can\'t be accessed by other apps or by a possible intruder. Once you save the recording, you will be asked where you want to save the recording to.</string>
@@ -200,7 +200,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">You will now be asked to select a folder where Alibi should store the batches. Please select a folder where you have write access to.</string>
     <string name="ui_welcome_timeSettings_values_custom">Custom Duration</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s minutes</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s hour, %s minutes</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s hour, %2$s minutes</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 hour, %s minutes</string>
     <string name="ui_welcome_ready_title">You are ready!</string>
     <string name="ui_welcome_ready_message">You are ready to start using Alibi! Go ahead and try it out!</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">Continuar</string>
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> KB/s</string>
     <string name="form_error_type_notNumber">Por favor, insira um número válido</string>
-    <string name="form_error_value_notInRange">Por favor, insira um número entre <xliff:g name="min">%s</xliff:g> e <xliff:g name="max">%s</xliff:g></string>
+    <string name="form_error_value_notInRange">Por favor, insira um número entre <xliff:g name="min">%1$s</xliff:g> e <xliff:g name="max">%2$s</xliff:g></string>
     <string name="form_error_value_mustBeGreaterThan">Por favor, insira um número maior que <xliff:g name="min">%s</xliff:g></string>
     <string name="form_value_selected">Selecionado: %s</string>
     <string name="a11y_selectValue">Select %s</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">Microfone do Dispositivo</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">O microfone selecionado será ativado imediatamente</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">Microfone desconectado</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> desconectado. Alibi usará o microfone padrão em vez disso. <xliff:g name="nam">%s</xliff:g> será usado automaticamente assim que for reconectado.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> desconectado. Alibi usará o microfone padrão em vez disso. <xliff:g name="nam">%2$s</xliff:g> será usado automaticamente assim que for reconectado.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">Microfone reconectado</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message"><xliff:g name="name">%s</xliff:g> reconectado! Alibi alterou automaticamente a entrada de microfone para ele.</string>
     <string name="ui_settings_option_showAllMicrophones_title">Mostrar microfones ocultos</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">Verificação necessária</string>
     <string name="identityVerificationRequired_subtitle">Você precisa verificar sua identidade para continuar</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Pastas personalizadas para Gravações de Vídeo não são suportadas pela sua versão do Android. O Alibi irá retornar para a pasta interna para de Gravações de Vídeo.</string>
-    <string name="ui_minApiRequired">Você vai precisar de um celular Android rodando pelo menos o Android %s (API-Nível: %s) para usar este recurso</string>
+    <string name="ui_minApiRequired">Você vai precisar de um celular Android rodando pelo menos o Android %1$s (API-Nível: %2$s) para usar este recurso</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Selecione uma localização personalizada</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">Usar a pasta DCIM</string>
     <string name="ui_settings_option_saveFolder_dcimValue">Pasta DCIM</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Abrir pasta selecionada no gerenciador de arquivos</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Onde meus lotes estão armazenados?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">Para ver seus lotes, abra o aplicativo Arquivos, vá para o armazenamento interno e então você encontrará seus lotes nas seguintes pastas:</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">As últimas gravações mescladas serão salvas nessas pastas. Cada gravação cria uma subpasta para armazenar os lotes curtos em (\"%s\" para gravações de áudio, \"%s\" para gravações de vídeo). Para ver os lotes individuais, talvez seja necessário habilitar os arquivos ocultos no app Arquivos.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">As últimas gravações mescladas serão salvas nessas pastas. Cada gravação cria uma subpasta para armazenar os lotes curtos em (\"%1$s\" para gravações de áudio, \"%2$s\" para gravações de vídeo). Para ver os lotes individuais, talvez seja necessário habilitar os arquivos ocultos no app Arquivos.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Toque em uma pasta para abri-la no aplicativo Arquivos</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Desconhecido</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">Para proteger sua privacidade, o Alibi armazena seus lotes em seu próprio armazenamento privado e criptografado. Este armazenamento só é acessível pelo Alibi e não pode ser acessado por outros aplicativos ou por um possível invasor. Depois de salvar a gravação, você será perguntado para onde deseja salvar a gravação.</string>
@@ -200,7 +200,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">You will now be asked to select a folder where Alibi should store the batches. Please select a folder where you have write access to.</string>
     <string name="ui_welcome_timeSettings_values_custom">Custom Duration</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s minutes</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s hour, %s minutes</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s hour, %2$s minutes</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 hour, %s minutes</string>
     <string name="ui_welcome_ready_title">You are ready!</string>
     <string name="ui_welcome_ready_message">You are ready to start using Alibi! Go ahead and try it out!</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">Continue</string>
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> KB/s</string>
     <string name="form_error_type_notNumber">Please enter a valid number</string>
-    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%s</xliff:g> and <xliff:g name="max">%s</xliff:g></string>
+    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%1$s</xliff:g> and <xliff:g name="max">%2$s</xliff:g></string>
     <string name="form_error_value_mustBeGreaterThan">Please enter a number greater than <xliff:g name="min">%s</xliff:g></string>
     <string name="form_value_selected">Selected: %s</string>
     <string name="a11y_selectValue">Select %s</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">Device Microphone</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">The selected microphone will be activated immediately</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">Microphone disconnected</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%s</xliff:g> once it reconnects.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%2$s</xliff:g> once it reconnects.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">Microphone reconnected</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message"><xliff:g name="name">%s</xliff:g> reconnected! Alibi automatically changed the microphone input to it.</string>
     <string name="ui_settings_option_showAllMicrophones_title">Show hidden microphones</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">Verification required</string>
     <string name="identityVerificationRequired_subtitle">You need to verify your identity to continue</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Custom folders for Video Recordings aren\'t supported by your Android version. Alibi will fallback to the internal folder instead for Video Recordings.</string>
-    <string name="ui_minApiRequired">You will need an Android phone running at least Android %s (API-Level: %s) to use this feature</string>
+    <string name="ui_minApiRequired">You will need an Android phone running at least Android %1$s (API-Level: %2$s) to use this feature</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Select a custom location</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">Use the DCIM folder</string>
     <string name="ui_settings_option_saveFolder_dcimValue">DCIM Folder</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Open selected folder in file manager</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Where are my batches stored?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">To view your batches, open the Files app, go to the internal storage and then you will find your batches in following folders:</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%s\" for audio recordings, \"%s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%1$s\" for audio recordings, \"%2$s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Tap on a folder to open it in the Files app</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Unknown</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">To protect your privacy, Alibi stores its batches into its own private, encrypted storage. This storage is only accessible by Alibi and can\'t be accessed by other apps or by a possible intruder. Once you save the recording, you will be asked where you want to save the recording to.</string>
@@ -200,7 +200,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">You will now be asked to select a folder where Alibi should store the batches. Please select a folder where you have write access to.</string>
     <string name="ui_welcome_timeSettings_values_custom">Custom Duration</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s minutes</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s hour, %s minutes</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s hour, %2$s minutes</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 hour, %s minutes</string>
     <string name="ui_welcome_ready_title">You are ready!</string>
     <string name="ui_welcome_ready_message">You are ready to start using Alibi! Go ahead and try it out!</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">Продолжить</string>
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> КБ/с</string>
     <string name="form_error_type_notNumber">Пожалуйста, введите правильное число</string>
-    <string name="form_error_value_notInRange">Пожалуйста, введите число между <xliff:g name="min">%s</xliff:g> и <xliff:g name="max">%s</xliff:g></string>
+    <string name="form_error_value_notInRange">Пожалуйста, введите число между <xliff:g name="min">%1$s</xliff:g> и <xliff:g name="max">%2$s</xliff:g></string>
     <string name="form_error_value_mustBeGreaterThan">Пожалуйста, введите число, превышающее <xliff:g name="min">%s</xliff:g></string>
     <string name="form_value_selected"></string>
     <string name="a11y_selectValue">Select %s</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">Микрофон устройства</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">Выбранный микрофон будет активирован немедленно</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">Микрофон отключен</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> отключился. Alibi будет использовать вместо этого микрофон по умолчанию. Мы автоматически вернемся к <xliff:g name="nam">%s</xliff:g> после повторного подключения.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> отключился. Alibi будет использовать вместо этого микрофон по умолчанию. Мы автоматически вернемся к <xliff:g name="nam">%2$s</xliff:g> после повторного подключения.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">Микрофон переподключен</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message"><xliff:g name="name">%s</xliff:g> переподключен! Alibi автоматически изменил ввод микрофона.</string>
     <string name="ui_settings_option_showAllMicrophones_title">Показать скрытые микрофоны</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">Verification required</string>
     <string name="identityVerificationRequired_subtitle">You need to verify your identity to continue</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Custom folders for Video Recordings aren\'t supported by your Android version. Alibi will fallback to the internal folder instead for Video Recordings.</string>
-    <string name="ui_minApiRequired">You will need an Android phone running at least Android %s (API-Level: %s) to use this feature</string>
+    <string name="ui_minApiRequired">You will need an Android phone running at least Android %1$s (API-Level: %2$s) to use this feature</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Select a custom location</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">Use the DCIM folder</string>
     <string name="ui_settings_option_saveFolder_dcimValue">DCIM Folder</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Open selected folder in file manager</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Where are my batches stored?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">To view your batches, open the Files app, go to the internal storage and then you will find your batches in following folders:</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%s\" for audio recordings, \"%s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%1$s\" for audio recordings, \"%2$s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Tap on a folder to open it in the Files app</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Unknown</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">To protect your privacy, Alibi stores its batches into its own private, encrypted storage. This storage is only accessible by Alibi and can\'t be accessed by other apps or by a possible intruder. Once you save the recording, you will be asked where you want to save the recording to.</string>
@@ -200,7 +200,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">You will now be asked to select a folder where Alibi should store the batches. Please select a folder where you have write access to.</string>
     <string name="ui_welcome_timeSettings_values_custom">Custom Duration</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s minutes</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s hour, %s minutes</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s hour, %2$s minutes</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 hour, %s minutes</string>
     <string name="ui_welcome_ready_title">You are ready!</string>
     <string name="ui_welcome_ready_message">You are ready to start using Alibi! Go ahead and try it out!</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">Continue</string>
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> KB/s</string>
     <string name="form_error_type_notNumber">Please enter a valid number</string>
-    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%s</xliff:g> and <xliff:g name="max">%s</xliff:g></string>
+    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%1$s</xliff:g> and <xliff:g name="max">%2$s</xliff:g></string>
     <string name="form_error_value_mustBeGreaterThan">Please enter a number greater than <xliff:g name="min">%s</xliff:g></string>
     <string name="form_value_selected">Selected: %s</string>
     <string name="a11y_selectValue">Select %s</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">Device Microphone</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">The selected microphone will be activated immediately</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">Microphone disconnected</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%s</xliff:g> once it reconnects.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%2$s</xliff:g> once it reconnects.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">Microphone reconnected</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message"><xliff:g name="name">%s</xliff:g> reconnected! Alibi automatically changed the microphone input to it.</string>
     <string name="ui_settings_option_showAllMicrophones_title">Show hidden microphones</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">Verification required</string>
     <string name="identityVerificationRequired_subtitle">You need to verify your identity to continue</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Custom folders for Video Recordings aren\'t supported by your Android version. Alibi will fallback to the internal folder instead for Video Recordings.</string>
-    <string name="ui_minApiRequired">You will need an Android phone running at least Android %s (API-Level: %s) to use this feature</string>
+    <string name="ui_minApiRequired">You will need an Android phone running at least Android %1$s (API-Level: %2$s) to use this feature</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Select a custom location</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">Use the DCIM folder</string>
     <string name="ui_settings_option_saveFolder_dcimValue">DCIM Folder</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Open selected folder in file manager</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Where are my batches stored?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">To view your batches, open the Files app, go to the internal storage and then you will find your batches in following folders:</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%s\" for audio recordings, \"%s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%1$s\" for audio recordings, \"%2$s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Tap on a folder to open it in the Files app</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Unknown</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">To protect your privacy, Alibi stores its batches into its own private, encrypted storage. This storage is only accessible by Alibi and can\'t be accessed by other apps or by a possible intruder. Once you save the recording, you will be asked where you want to save the recording to.</string>
@@ -200,7 +200,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">You will now be asked to select a folder where Alibi should store the batches. Please select a folder where you have write access to.</string>
     <string name="ui_welcome_timeSettings_values_custom">Custom Duration</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s minutes</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s hour, %s minutes</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s hour, %2$s minutes</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 hour, %s minutes</string>
     <string name="ui_welcome_ready_title">You are ready!</string>
     <string name="ui_welcome_ready_message">You are ready to start using Alibi! Go ahead and try it out!</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">Continue</string>
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> KB/s</string>
     <string name="form_error_type_notNumber">Please enter a valid number</string>
-    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%s</xliff:g> and <xliff:g name="max">%s</xliff:g></string>
+    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%1$s</xliff:g> and <xliff:g name="max">%2$s</xliff:g></string>
     <string name="form_error_value_mustBeGreaterThan">Please enter a number greater than <xliff:g name="min">%s</xliff:g></string>
     <string name="form_value_selected">Selected: %s</string>
     <string name="a11y_selectValue">Select %s</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">Device Microphone</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">The selected microphone will be activated immediately</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">Microphone disconnected</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%s</xliff:g> once it reconnects.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%2$s</xliff:g> once it reconnects.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">Microphone reconnected</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message"><xliff:g name="name">%s</xliff:g> reconnected! Alibi automatically changed the microphone input to it.</string>
     <string name="ui_settings_option_showAllMicrophones_title">Show hidden microphones</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">Verification required</string>
     <string name="identityVerificationRequired_subtitle">You need to verify your identity to continue</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Custom folders for Video Recordings aren\'t supported by your Android version. Alibi will fallback to the internal folder instead for Video Recordings.</string>
-    <string name="ui_minApiRequired">You will need an Android phone running at least Android %s (API-Level: %s) to use this feature</string>
+    <string name="ui_minApiRequired">You will need an Android phone running at least Android %1$s (API-Level: %2$s) to use this feature</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Select a custom location</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">Use the DCIM folder</string>
     <string name="ui_settings_option_saveFolder_dcimValue">DCIM Folder</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Open selected folder in file manager</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Where are my batches stored?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">To view your batches, open the Files app, go to the internal storage and then you will find your batches in following folders:</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%s\" for audio recordings, \"%s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%1$s\" for audio recordings, \"%2$s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Tap on a folder to open it in the Files app</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Unknown</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">To protect your privacy, Alibi stores its batches into its own private, encrypted storage. This storage is only accessible by Alibi and can\'t be accessed by other apps or by a possible intruder. Once you save the recording, you will be asked where you want to save the recording to.</string>
@@ -200,7 +200,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">You will now be asked to select a folder where Alibi should store the batches. Please select a folder where you have write access to.</string>
     <string name="ui_welcome_timeSettings_values_custom">Custom Duration</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s minutes</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s hour, %s minutes</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s hour, %2$s minutes</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 hour, %s minutes</string>
     <string name="ui_welcome_ready_title">You are ready!</string>
     <string name="ui_welcome_ready_message">You are ready to start using Alibi! Go ahead and try it out!</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">Devam</string>
     <string name="format_kbps">        <xliff:g name="value">%s</xliff:g> KB/sn</string>
     <string name="form_error_type_notNumber">Lütfen geçerli bir sayı girin</string>
-    <string name="form_error_value_notInRange">Lütfen arasında bir sayı girin <xliff:g name="min">%s</xliff:g> ve <xliff:g name="max">%s</xliff:g></string>
+    <string name="form_error_value_notInRange">Lütfen arasında bir sayı girin <xliff:g name="min">%1$s</xliff:g> ve <xliff:g name="max">%2$s</xliff:g></string>
     <string name="form_error_value_mustBeGreaterThan">Lütfen daha büyük bir sayı girin <xliff:g name="min">%s</xliff:g></string>
     <string name="form_value_selected">Seçilen: %s</string>
     <string name="a11y_selectValue">%s\'i seçin</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">Cihaz Mikrofonu</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">Seçilen mikrofon hemen etkinleştirilecektir</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">Mikrofon bağlantısı kesildi</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message">        <xliff:g name="name">%s</xliff:g> bağlantısı kesildi. Alibi bunun yerine varsayılan mikrofonu kullanacak. Otomatik olarak şuna geri döneceğiz: <xliff:g name="nam">%s</xliff:g> yeniden bağlandığında.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message">        <xliff:g name="name">%1$s</xliff:g> bağlantısı kesildi. Alibi bunun yerine varsayılan mikrofonu kullanacak. Otomatik olarak şuna geri döneceğiz: <xliff:g name="nam">%2$s</xliff:g> yeniden bağlandığında.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">Mikrofon yeniden bağlandı</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message">        <xliff:g name="name">%s</xliff:g> yeniden bağlandı! Alibi mikrofon girişini otomatik olarak değiştirdi.</string>
     <string name="ui_settings_option_showAllMicrophones_title">Gizli mikrofonları göster</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">Doğrulama gerekli</string>
     <string name="identityVerificationRequired_subtitle">Devam etmek için kimliğinizi doğrulamanız gerekiyor</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Video Kayıtları için özel klasörler Android sürümünüz tarafından desteklenmiyor. Alibi, Video Kayıtları için dahili klasöre geri dönecektir.</string>
-    <string name="ui_minApiRequired">Bu özelliği kullanmak için en az Android %s (API Seviyesi: %s) çalıştıran bir Android telefona ihtiyacınız olacak</string>
+    <string name="ui_minApiRequired">Bu özelliği kullanmak için en az Android %1$s (API Seviyesi: %2$s) çalıştıran bir Android telefona ihtiyacınız olacak</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Özel bir konum seçin</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">DCIM klasörünü kullanın</string>
     <string name="ui_settings_option_saveFolder_dcimValue">DCIM Klasörü</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Seçilen klasörü dosya yöneticisinde aç</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Partilerim nerede saklanıyor?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">Partilerinizi görüntülemek için Dosyalar uygulamasını açın, dahili depoya gidin ve ardından partilerinizi aşağıdaki klasörlerde bulacaksınız:</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">Birleştirilen son kayıtlar bu klasörlere kaydedilecektir. Her kayıt, kısa yığınları depolamak için bir alt klasör oluşturur (ses kayıtları için \" %s \", video kayıtları için \" %s \"). Tek tek yığınları görüntülemek için Dosyalar uygulamasında gizli dosyaları etkinleştirmeniz gerekebilir.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">Birleştirilen son kayıtlar bu klasörlere kaydedilecektir. Her kayıt, kısa yığınları depolamak için bir alt klasör oluşturur (ses kayıtları için \" %1$s \", video kayıtları için \" %2$s \"). Tek tek yığınları görüntülemek için Dosyalar uygulamasında gizli dosyaları etkinleştirmeniz gerekebilir.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Dosyalar uygulamasında açmak için bir klasöre dokunun</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Bilinmiyor</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">Alibi, gizliliğinizi korumak için partilerini kendi özel, şifreli deposunda saklar. Bu depolama alanına yalnızca Alibi tarafından erişilebilir ve diğer uygulamalar veya olası bir davetsiz misafir tarafından erişilemez. Kaydı kaydettikten sonra, kaydı nereye kaydetmek istediğiniz sorulacaktır.</string>
@@ -200,7 +200,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">Şimdi Alibi\'nin partileri saklaması gereken bir klasör seçmeniz istenecektir. Lütfen yazma erişiminizin olduğu bir klasör seçin.</string>
     <string name="ui_welcome_timeSettings_values_custom">Özel Süre</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s dakika</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s saat, %s dakika</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s saat, %2$s dakika</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 saat, %s dakika</string>
     <string name="ui_welcome_ready_title">Hazırsınız!</string>
     <string name="ui_welcome_ready_message">Alibi kullanmaya başlamaya hazırsınız! Devam et ve dene!</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">Продовжити</string>
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> KБ/с</string>
     <string name="form_error_type_notNumber">Будь ласка, введіть дійсне число</string>
-    <string name="form_error_value_notInRange">Будь ласка, введіть номер між <xliff:g name="min">%s</xliff:g> та <xliff:g name="max">%s</xliff:g></string>
+    <string name="form_error_value_notInRange">Будь ласка, введіть номер між <xliff:g name="min">%1$s</xliff:g> та <xliff:g name="max">%2$s</xliff:g></string>
     <string name="form_error_value_mustBeGreaterThan">Будь ласка, введіть число більше, ніж <xliff:g name="min">%s</xliff:g></string>
     <string name="form_value_selected">Обрано: %s</string>
     <string name="a11y_selectValue">Оберіть %s</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">Device Microphone</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">The selected microphone will be activated immediately</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">Microphone disconnected</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%s</xliff:g> once it reconnects.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%2$s</xliff:g> once it reconnects.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">Microphone reconnected</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message"><xliff:g name="name">%s</xliff:g> reconnected! Alibi automatically changed the microphone input to it.</string>
     <string name="ui_settings_option_showAllMicrophones_title">Show hidden microphones</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">Verification required</string>
     <string name="identityVerificationRequired_subtitle">You need to verify your identity to continue</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Custom folders for Video Recordings aren\'t supported by your Android version. Alibi will fallback to the internal folder instead for Video Recordings.</string>
-    <string name="ui_minApiRequired">You will need an Android phone running at least Android %s (API-Level: %s) to use this feature</string>
+    <string name="ui_minApiRequired">You will need an Android phone running at least Android %1$s (API-Level: %2$s) to use this feature</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Select a custom location</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">Use the DCIM folder</string>
     <string name="ui_settings_option_saveFolder_dcimValue">DCIM Folder</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Open selected folder in file manager</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Where are my batches stored?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">To view your batches, open the Files app, go to the internal storage and then you will find your batches in following folders:</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%s\" for audio recordings, \"%s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%1$s\" for audio recordings, \"%2$s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Tap on a folder to open it in the Files app</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Unknown</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">To protect your privacy, Alibi stores its batches into its own private, encrypted storage. This storage is only accessible by Alibi and can\'t be accessed by other apps or by a possible intruder. Once you save the recording, you will be asked where you want to save the recording to.</string>
@@ -200,7 +200,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">You will now be asked to select a folder where Alibi should store the batches. Please select a folder where you have write access to.</string>
     <string name="ui_welcome_timeSettings_values_custom">Custom Duration</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s minutes</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s hour, %s minutes</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s hour, %2$s minutes</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 hour, %s minutes</string>
     <string name="ui_welcome_ready_title">You are ready!</string>
     <string name="ui_welcome_ready_message">You are ready to start using Alibi! Go ahead and try it out!</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">Continue</string>
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> KB/s</string>
     <string name="form_error_type_notNumber">Please enter a valid number</string>
-    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%s</xliff:g> and <xliff:g name="max">%s</xliff:g></string>
+    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%1$s</xliff:g> and <xliff:g name="max">%2$s</xliff:g></string>
     <string name="form_error_value_mustBeGreaterThan">Please enter a number greater than <xliff:g name="min">%s</xliff:g></string>
     <string name="form_value_selected">Selected: %s</string>
     <string name="a11y_selectValue">Select %s</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">Device Microphone</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">The selected microphone will be activated immediately</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">Microphone disconnected</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%s</xliff:g> once it reconnects.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%2$s</xliff:g> once it reconnects.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">Microphone reconnected</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message"><xliff:g name="name">%s</xliff:g> reconnected! Alibi automatically changed the microphone input to it.</string>
     <string name="ui_settings_option_showAllMicrophones_title">Show hidden microphones</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">Verification required</string>
     <string name="identityVerificationRequired_subtitle">You need to verify your identity to continue</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Custom folders for Video Recordings aren\'t supported by your Android version. Alibi will fallback to the internal folder instead for Video Recordings.</string>
-    <string name="ui_minApiRequired">You will need an Android phone running at least Android %s (API-Level: %s) to use this feature</string>
+    <string name="ui_minApiRequired">You will need an Android phone running at least Android %1$s (API-Level: %2$s) to use this feature</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Select a custom location</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">Use the DCIM folder</string>
     <string name="ui_settings_option_saveFolder_dcimValue">DCIM Folder</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Open selected folder in file manager</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Where are my batches stored?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">To view your batches, open the Files app, go to the internal storage and then you will find your batches in following folders:</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%s\" for audio recordings, \"%s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%1$s\" for audio recordings, \"%2$s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Tap on a folder to open it in the Files app</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Unknown</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">To protect your privacy, Alibi stores its batches into its own private, encrypted storage. This storage is only accessible by Alibi and can\'t be accessed by other apps or by a possible intruder. Once you save the recording, you will be asked where you want to save the recording to.</string>
@@ -200,7 +200,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">You will now be asked to select a folder where Alibi should store the batches. Please select a folder where you have write access to.</string>
     <string name="ui_welcome_timeSettings_values_custom">Custom Duration</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s minutes</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s hour, %s minutes</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s hour, %2$s minutes</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 hour, %s minutes</string>
     <string name="ui_welcome_ready_title">You are ready!</string>
     <string name="ui_welcome_ready_message">You are ready to start using Alibi! Go ahead and try it out!</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -6,7 +6,7 @@
     <string name="continue_label">继续</string>
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> KB/s</string>
     <string name="form_error_type_notNumber">请输入有效数字</string>
-    <string name="form_error_value_notInRange">请输入 <xliff:g name="min">%s</xliff:g> 到 <xliff:g name="max">%s</xliff:g> 之间的数</string>
+    <string name="form_error_value_notInRange">请输入 <xliff:g name="min">%1$s</xliff:g> 到 <xliff:g name="max">%2$s</xliff:g> 之间的数</string>
     <string name="form_error_value_mustBeGreaterThan">请输入大于 <xliff:g name="min">%s</xliff:g> 的数</string>
     <string name="form_value_selected">已选中：%s</string>
     <string name="a11y_selectValue">选择 %s</string>
@@ -72,7 +72,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">设备麦克风</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">选中的麦克风将立即激活</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">麦克风连接已断开</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> 连接已断开。Alibi 将使用默认麦克风。一旦重新连接，我们将自动重新切换到 <xliff:g name="nam">%s</xliff:g>。</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> 连接已断开。Alibi 将使用默认麦克风。一旦重新连接，我们将自动重新切换到 <xliff:g name="nam">%2$s</xliff:g>。</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">麦克风已重新连接</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message"><xliff:g name="name">%s</xliff:g> 已重新连接！Alibi 已自动更改麦克风输入。</string>
     <string name="ui_settings_option_showAllMicrophones_title">显示隐藏的麦克风</string>
@@ -158,7 +158,7 @@
     <string name="identityVerificationRequired_title">需要验证</string>
     <string name="identityVerificationRequired_subtitle">您需要验证身份才能继续</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">您的 Android 版本不支持用于视频录制的自定义文件夹。Alibi 将取消录制并返回系统文件夹。</string>
-    <string name="ui_minApiRequired">您将需要至少运行 Android %s (API 级别: %s) 的 Android 手机来使用此功能</string>
+    <string name="ui_minApiRequired">您将需要至少运行 Android %1$s (API 级别: %2$s) 的 Android 手机来使用此功能</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">选择自定义位置</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">使用 DCIM 文件夹</string>
     <string name="ui_settings_option_saveFolder_dcimValue">DCIM 文件夹</string>
@@ -173,7 +173,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">在文件管理器中打开选定的文件夹</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">我录制的片段保存在哪里？</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">要查看您录制的片段，请打开文件管理应用程序，转到内部存储，然后您将在以下文件夹中找到您录制的片段文件：</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">最后合并的录制文件将保存到这些文件夹中。 每个录制件都创建一个子文件夹，将短片段存储在(\"%s\"用于录制音频，\"%s\"用于录制视频)。 要查看单个片段，您可能需要在文件管理应用中启用查看隐藏文件。</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">最后合并的录制文件将保存到这些文件夹中。 每个录制件都创建一个子文件夹，将短片段存储在(\"%1$s\"用于录制音频，\"%2$s\"用于录制视频)。 要查看单个片段，您可能需要在文件管理应用中启用查看隐藏文件。</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">点击文件夹在文件管理应用中打开</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">未知</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">为了保护您的隐私，Alibi 将录制的片段存储到自己的私有加密存储中。 此存储仅供 Alibi 访问，不能被其他应用或可能的入侵者访问。一旦您保存录制，您将被询问您想要将录制保存到哪里。</string>
@@ -200,7 +200,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">您需要选择一个 Alibi 存储录制片段的文件夹。请选择一个您拥有写访问权限的文件夹。</string>
     <string name="ui_welcome_timeSettings_values_custom">自定义时长</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s 分钟</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s 小时, %s 分钟</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s 小时, %2$s 分钟</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 小时, %s 分钟</string>
     <string name="ui_welcome_ready_title">您已准备就绪！</string>
     <string name="ui_welcome_ready_message">您已准备好使用 Alibi！请继续尝试吧！</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,7 +7,7 @@
 
     <string name="format_kbps"><xliff:g name="value">%s</xliff:g> KB/s</string>
     <string name="form_error_type_notNumber">Please enter a valid number</string>
-    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%s</xliff:g> and <xliff:g name="max">%s</xliff:g></string>
+    <string name="form_error_value_notInRange">Please enter a number between <xliff:g name="min">%1$s</xliff:g> and <xliff:g name="max">%2$s</xliff:g></string>
     <string name="form_error_value_mustBeGreaterThan">Please enter a number greater than <xliff:g name="min">%s</xliff:g></string>
     <string name="form_value_selected">Selected: %s</string>
 
@@ -86,7 +86,7 @@
     <string name="ui_audioRecorder_info_microphone_deviceMicrophone">Device Microphone</string>
     <string name="ui_audioRecorder_info_microphone_changeExplanation">The selected microphone will be activated immediately</string>
     <string name="ui_audioRecorder_error_microphoneDisconnected_title">Microphone disconnected</string>
-    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%s</xliff:g> once it reconnects.</string>
+    <string name="ui_audioRecorder_error_microphoneDisconnected_message"><xliff:g name="name">%1$s</xliff:g> disconnected. Alibi will use the default microphone instead. We will automatically switch back to <xliff:g name="nam">%2$s</xliff:g> once it reconnects.</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_title">Microphone reconnected</string>
     <string name="ui_audioRecorder_error_microphoneReconnected_message"><xliff:g name="name">%s</xliff:g> reconnected! Alibi automatically changed the microphone input to it.</string>
     <string name="ui_settings_option_showAllMicrophones_title">Show hidden microphones</string>
@@ -172,7 +172,7 @@
     <string name="identityVerificationRequired_title">Verification required</string>
     <string name="identityVerificationRequired_subtitle">You need to verify your identity to continue</string>
     <string name="ui_settings_option_saveFolder_videoUnsupported">Custom folders for Video Recordings aren\'t supported by your Android version. Alibi will fallback to the internal folder instead for Video Recordings.</string>
-    <string name="ui_minApiRequired">You will need an Android phone running at least Android %s (API-Level: %s) to use this feature</string>
+    <string name="ui_minApiRequired">You will need an Android phone running at least Android %1$s (API-Level: %2$s) to use this feature</string>
     <string name="ui_settings_option_saveFolder_action_custom_label">Select a custom location</string>
     <string name="ui_settings_option_saveFolder_action_dcim_label">Use the DCIM folder</string>
     <string name="ui_settings_option_saveFolder_dcimValue">DCIM Folder</string>
@@ -187,7 +187,7 @@
     <string name="ui_settings_option_saveFolder_openFolder_label">Open selected folder in file manager</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_label">Where are my batches stored?</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_generalExplanation">To view your batches, open the Files app, go to the internal storage and then you will find your batches in following folders:</string>
-    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%s\" for audio recordings, \"%s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
+    <string name="ui_settings_option_saveFolder_explainMediaFolder_subfoldersExplanation">The final merged recordings will be saved in those folders. Each recording creates a subfolder to store the short batches in (\"%1$s\" for audio recordings, \"%2$s\" for video recordings). To view the individual batches, you may need to enable hidden files in the Files app.</string>
     <string name="ui_settings_option_saveFolder_explainMediaFolder_openFolderExplanation">Tap on a folder to open it in the Files app</string>
     <string name="ui_videoRecorder_action_start_settings_cameraLens_unknown_label">Unknown</string>
     <string name="ui_settings_option_saveFolder_explainInternalFolder_explanation">To protect your privacy, Alibi stores its batches into its own private, encrypted storage. This storage is only accessible by Alibi and can\'t be accessed by other apps or by a possible intruder. Once you save the recording, you will be asked where you want to save the recording to.</string>
@@ -214,7 +214,7 @@
     <string name="ui_welcome_saveFolder_customFolder_message">You will now be asked to select a folder where Alibi should store the batches. Please select a folder where you have write access to.</string>
     <string name="ui_welcome_timeSettings_values_custom">Custom Duration</string>
     <string name="ui_welcome_timeSettings_values_customFormat_mm">%s minutes</string>
-    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%s hour, %s minutes</string>
+    <string name="ui_welcome_timeSettings_values_customFormat_hh_mm">%1$s hour, %2$s minutes</string>
     <string name="ui_welcome_timeSettings_values_customFormat_h_mm">1 hour, %s minutes</string>
     <string name="ui_welcome_ready_title">You are ready!</string>
     <string name="ui_welcome_ready_message">You are ready to start using Alibi! Go ahead and try it out!</string>


### PR DESCRIPTION
Resource merging warned for every locale whose strings used multiple non-positional %s placeholders. Android format strings with more than one substitution need explicit argument positions, otherwise translators can reorder them and runtime formatting silently swaps values.

Convert the affected strings across all locales to %1$s / %2$s form.